### PR TITLE
fix: route post-execution review to Loom when plan completes

### DIFF
--- a/src/hooks/work-continuation.test.ts
+++ b/src/hooks/work-continuation.test.ts
@@ -35,12 +35,16 @@ describe("checkContinuation", () => {
     expect(result.continuationPrompt).toBeNull()
   })
 
-  it("returns null when plan is complete", () => {
+  it("returns review handoff when plan is complete", () => {
     const planPath = createPlanFile("done", "# Done\n- [x] Task 1\n- [x] Task 2\n")
     writeWorkState(testDir, createWorkState(planPath, "sess_1"))
 
     const result = checkContinuation({ sessionId: "sess_1", directory: testDir })
-    expect(result.continuationPrompt).toBeNull()
+    expect(result.continuationPrompt).not.toBeNull()
+    expect(result.targetAgent).toBe("loom")
+    expect(result.continuationPrompt).toContain("post-execution review")
+    expect(result.continuationPrompt).toContain("Weft")
+    expect(result.continuationPrompt).toContain("Warp")
   })
 
   it("returns null when plan file is missing", () => {
@@ -57,6 +61,7 @@ describe("checkContinuation", () => {
 
     const result = checkContinuation({ sessionId: "sess_1", directory: testDir })
     expect(result.continuationPrompt).not.toBeNull()
+    expect(result.targetAgent).toBeUndefined()
     expect(result.continuationPrompt).toContain("my-plan")
     expect(result.continuationPrompt).toContain("1/3 tasks completed")
     expect(result.continuationPrompt).toContain("2 remaining")

--- a/src/plugin/plugin-interface.ts
+++ b/src/plugin/plugin-interface.ts
@@ -189,10 +189,14 @@ export function createPluginInterface(args: {
               await client.session.promptAsync({
                 path: { id: sessionId },
                 body: {
+                  ...(result.targetAgent ? { agent: result.targetAgent } : {}),
                   parts: [{ type: "text", text: result.continuationPrompt }],
                 },
               })
-              log("[work-continuation] Injected continuation prompt", { sessionId })
+              log("[work-continuation] Injected continuation prompt", {
+                sessionId,
+                ...(result.targetAgent ? { targetAgent: result.targetAgent } : {}),
+              })
             } catch (err) {
               log("[work-continuation] Failed to inject continuation", { sessionId, error: String(err) })
             }

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -558,7 +558,9 @@ describe("Integration: createHooks wired workflow", () => {
     markTaskComplete(planPath, 0)
     markTaskComplete(planPath, 0)
     const cont2 = hooks.workContinuation!("sess_1")
-    expect(cont2.continuationPrompt).toBeNull()
+    expect(cont2.continuationPrompt).not.toBeNull()
+    expect(cont2.targetAgent).toBe("loom")
+    expect(cont2.continuationPrompt).toContain("post-execution review")
   })
 
   it("verificationReminder is wired and uses self-verification protocol", () => {
@@ -689,9 +691,11 @@ describe("Full Lifecycle: Pattern → /start-work → Execute → Idle → Resum
     const progress2 = getPlanProgress(planPath)
     expect(progress2).toMatchObject({ total: 4, completed: 4, isComplete: true })
 
-    // 14. No more continuation
+    // 14. Completed plan triggers review handoff to Loom
     const cont2 = checkContinuation({ sessionId: "sess_2", directory: testDir })
-    expect(cont2.continuationPrompt).toBeNull()
+    expect(cont2.continuationPrompt).not.toBeNull()
+    expect(cont2.targetAgent).toBe("loom")
+    expect(cont2.continuationPrompt).toContain("post-execution review")
 
     // 15. Verification reminder at completion uses self-verification protocol
     const reminder2 = buildVerificationReminder({


### PR DESCRIPTION
## Summary

- Fixes the agent boundary gap where Loom was never notified after Tapestry completed a plan, causing mandatory post-execution reviews (Weft + Warp) to never trigger
- Uses the existing `agent` field on `promptAsync` to route the completion signal directly to Loom
- Adds a `total === 0` guard for missing/empty plan files

Closes #3

## Changes

| File | What |
|------|------|
| `src/hooks/work-continuation.ts` | Returns review handoff prompt with `targetAgent: "loom"` on plan completion instead of `null` |
| `src/plugin/plugin-interface.ts` | Passes `targetAgent` as the `agent` field in `promptAsync` call |
| `src/hooks/work-continuation.test.ts` | Updated completion test + added `targetAgent` assertions |
| `src/workflow.test.ts` | Updated 2 integration tests for new completion behavior |

## Testing

All 528 tests pass, 0 failures.