### PR TITLE
feat: support custom display names for builtin agents

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ flowchart LR
       "variant": "custom-variant-name",     // Prompt variant
       "skills": ["skill-1", "skill-2"],     // Inject skills
       "prompt_append": "Extra instructions", // Append to prompt
+      "display_name": "My Agent Name",      // Custom name shown in UI
       "tools": {                            // Per-tool toggles
         "bash": true,
         "write": false
@@ -119,6 +120,27 @@ Valid agent names for the `agents` config key:
 | `shuttle` | shuttle | Category specialist |
 
 > **Note**: Loom and Tapestry get title-cased display names with role descriptions. Subagents keep lowercase names.
+
+### Custom Display Names
+
+You can override the display name shown in the OpenCode UI for any builtin agent using the `display_name` field. This is useful for users who prefer agent names in their native language or a project-specific alias.
+
+```jsonc
+{
+  "agents": {
+    // Rename agents to Japanese
+    "loom": { "display_name": "織機 (メインオーケストレーター)" },
+    "thread": { "display_name": "糸 (コードベースエクスプローラー)" },
+    "pattern": { "display_name": "設計 (戦略プランナー)" },
+    "weft": { "display_name": "レビュー担当" }
+  }
+}
+```
+
+**Notes**:
+- The `display_name` only affects the UI label — all internal systems (workflows, `disabled_agents`, prompt references) continue to use the original config key (e.g., `"loom"`).
+- Setting `display_name` on a disabled agent is safe and has no effect on the UI.
+- Narration hints in Loom's system prompt use hardcoded names and will not reflect custom display names (known limitation).
 
 ## Config Pipeline (6 Phases)
 

--- a/src/agents/agent-builder.test.ts
+++ b/src/agents/agent-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock } from "bun:test"
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentFactory } from "./types"
-import { buildAgent, stripDisabledAgentReferences, registerAgentNameVariants } from "./agent-builder"
+import { buildAgent, stripDisabledAgentReferences, registerAgentNameVariants, addBuiltinNameVariant } from "./agent-builder"
 import type { CategoriesConfig } from "../config/schema"
 
 function makeFactory(baseConfig: Partial<AgentConfig> = {}): AgentFactory {
@@ -173,10 +173,10 @@ describe("stripDisabledAgentReferences", () => {
   it("uses word boundaries to avoid false positives", () => {
     const prompt = "threading is a pattern for concurrency\nUse thread for searches"
     const result = stripDisabledAgentReferences(prompt, new Set(["thread"]))
-    // "threading" contains "thread" but shouldn't match due to word boundary
-    // Actually "threading" starts with "thread" at a word boundary, so it will match
-    // The regex uses \b which treats word boundaries at the start
-    // Let's just verify the explicit thread line is removed
+    // "threading" contains "thread" but the negative lookahead (?!\w) prevents
+    // matching because "thread" is immediately followed by "i" (a word character).
+    // Only standalone "thread" (not part of a larger word) is matched and stripped.
+    expect(result).toContain("threading is a pattern for concurrency")
     expect(result).not.toContain("Use thread for searches")
   })
 
@@ -218,5 +218,43 @@ describe("registerAgentNameVariants", () => {
     const prompt = "Use Thread for exploration"
     const result = stripDisabledAgentReferences(prompt, new Set(["thread"]))
     expect(result).not.toContain("Thread")
+  })
+})
+
+describe("addBuiltinNameVariant", () => {
+  it("adds a new variant to an existing builtin", () => {
+    addBuiltinNameVariant("thread", "糸")
+    const prompt = "Use 糸 for codebase exploration\nKeep this"
+    const result = stripDisabledAgentReferences(prompt, new Set(["thread"]))
+    expect(result).not.toContain("糸")
+    expect(result).toContain("Keep this")
+  })
+
+  it("does not add duplicate variants", () => {
+    addBuiltinNameVariant("spindle", "MySpindle")
+    addBuiltinNameVariant("spindle", "MySpindle")
+    // A duplicate would cause a doubled regex alternation — just verify stripping still works
+    const prompt = "Use MySpindle for research\nKeep this"
+    const result = stripDisabledAgentReferences(prompt, new Set(["spindle"]))
+    expect(result).not.toContain("MySpindle")
+    expect(result).toContain("Keep this")
+  })
+
+  it("is a no-op for an unknown config key (no existing entry to append to)", () => {
+    // Should not throw and should not affect stripping of unknown agents
+    expect(() => addBuiltinNameVariant("nonexistent-agent", "SomeVariant")).not.toThrow()
+    const prompt = "Use SomeVariant for tasks"
+    // stripping by nonexistent-agent key has no registered variants so prompt is unchanged
+    const result = stripDisabledAgentReferences(prompt, new Set(["nonexistent-agent"]))
+    expect(result).toBe(prompt)
+  })
+
+  it("custom display name is stripped when builtin agent is disabled", () => {
+    addBuiltinNameVariant("pattern", "設計")
+    const prompt = "- Use 設計 for planning\n- Use thread for exploration\nKeep this"
+    const result = stripDisabledAgentReferences(prompt, new Set(["pattern"]))
+    expect(result).not.toContain("設計")
+    expect(result).toContain("thread")
+    expect(result).toContain("Keep this")
   })
 })

--- a/src/agents/agent-builder.ts
+++ b/src/agents/agent-builder.ts
@@ -22,8 +22,11 @@ type AgentConfigExtended = AgentConfig & {
  * Map from agent config key (lowercase) to display name variants that
  * might appear in prompt text. Used by stripDisabledAgentReferences to
  * remove lines that mention disabled agents.
+ *
+ * Exported for test cleanup — tests that call addBuiltinNameVariant
+ * must restore original arrays in afterEach to avoid state pollution.
  */
-const AGENT_NAME_VARIANTS: Record<string, string[]> = {
+export const AGENT_NAME_VARIANTS: Record<string, string[]> = {
   thread: ["thread", "Thread"],
   spindle: ["spindle", "Spindle"],
   weft: ["weft", "Weft"],
@@ -46,6 +49,20 @@ export function registerAgentNameVariants(name: string, variants?: string[]): vo
 }
 
 /**
+ * Add additional name variants for a builtin agent.
+ * Used when a user sets a custom display_name — the custom name
+ * must be included in variants so stripDisabledAgentReferences
+ * can match it when the agent is disabled.
+ * No-op if the config key has no existing variant entry or the variant is already present.
+ */
+export function addBuiltinNameVariant(configKey: string, variant: string): void {
+  const existing = AGENT_NAME_VARIANTS[configKey]
+  if (existing && !existing.includes(variant)) {
+    existing.push(variant)
+  }
+}
+
+/**
  * Remove lines from a prompt that reference disabled agents.
  * Only strips lines where an agent name appears as a standalone concept
  * (e.g. "Use thread (codebase explorer)"), not incidental word matches.
@@ -64,10 +81,11 @@ export function stripDisabledAgentReferences(prompt: string, disabled: Set<strin
   }
   if (disabledVariants.length === 0) return prompt
 
-  // Build a regex that matches any line containing a disabled agent name
-  // with word boundaries to avoid matching substrings (e.g. "pattern" in "patterns")
+  // Build a regex that matches any line containing a disabled agent name.
+  // Uses (?<!\w) and (?!\w) instead of \b to support Unicode/CJK display names
+  // while still avoiding false positives like "pattern" matching "patterns".
   const pattern = new RegExp(
-    `\\b(${disabledVariants.map((v) => v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\b`,
+    `(?<!\\w)(${disabledVariants.map((v) => v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})(?!\\w)`,
   )
 
   const lines = prompt.split("\n")

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -14,6 +14,8 @@ export const AgentOverrideConfigSchema = z.object({
   disable: z.boolean().optional(),
   mode: z.enum(["subagent", "primary", "all"]).optional(),
   maxTokens: z.number().optional(),
+  /** Custom display name shown in UI (overrides the default builtin name) */
+  display_name: z.string().optional(),
 })
 
 export const AgentOverridesSchema = z.record(z.string(), AgentOverrideConfigSchema)

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -9,6 +9,9 @@ import { BackgroundManager } from "./managers/background-manager"
 import { SkillMcpManager } from "./managers/skill-mcp-manager"
 import { createBuiltinAgents, registerCustomAgentMetadata } from "./agents/builtin-agents"
 import { buildCustomAgent, buildCustomAgentMetadata } from "./agents/custom-agent-factory"
+import { updateBuiltinDisplayName } from "./shared/agent-display-names"
+import { addBuiltinNameVariant } from "./agents/agent-builder"
+import { log } from "./shared/log"
 
 export interface WeaveManagers {
   configHandler: ConfigHandler
@@ -49,6 +52,35 @@ export function createManagers(options: {
     fingerprint,
     customAgentMetadata,
   })
+
+  // Step 2.5: Apply builtin display name overrides from config.
+  // Must happen after createBuiltinAgents() (so agents map is populated)
+  // and before ConfigHandler.handle() (so getAgentDisplayName returns the new name).
+  if (pluginConfig.agents) {
+    for (const [name, override] of Object.entries(pluginConfig.agents)) {
+      const displayName = override.display_name?.trim()
+      if (displayName) {
+        try {
+          updateBuiltinDisplayName(name, displayName)
+          addBuiltinNameVariant(name, displayName)
+          // MANDATORY: Guard against disabled agents where agents[name] is undefined.
+          // createBuiltinAgents() skips disabled agents, so agents[name] may not exist.
+          // Spreading undefined produces a broken config — this guard is required.
+          if (agents[name]) {
+            agents[name] = { ...agents[name], description: displayName }
+          }
+        } catch (err) {
+          // Only swallow "not a built-in agent" errors (non-builtin key in agents section).
+          // Re-throw unexpected errors so programming bugs surface.
+          if (err instanceof Error && err.message.includes("not a built-in agent")) {
+            log(`Skipping display_name override for non-builtin agent "${name}"`)
+          } else {
+            throw err
+          }
+        }
+      }
+    }
+  }
 
   // Step 3: Build custom agent configs and register metadata
   if (pluginConfig.custom_agents) {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, afterEach } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
 import WeavePlugin from "./index"
 import { createBuiltinAgents } from "./agents/builtin-agents"
 import { ConfigHandler } from "./managers/config-handler"
 import { WeaveConfigSchema } from "./config/schema"
-import { getAgentDisplayName } from "./shared/agent-display-names"
+import { getAgentDisplayName, getAgentConfigKey, AGENT_DISPLAY_NAMES } from "./shared/agent-display-names"
+import { createManagers } from "./create-managers"
+import { AGENT_NAME_VARIANTS } from "./agents/agent-builder"
 
 const makeMockCtx = (directory: string): PluginInput =>
   ({
@@ -110,5 +112,105 @@ describe("WeavePlugin integration", () => {
     expect(hooks.checkContextWindow).toBeNull()
     // Other hooks should still be enabled
     expect(hooks.writeGuard).not.toBeNull()
+  })
+})
+
+describe("createManagers — builtin display_name override", () => {
+  const mockCtx = {
+    directory: process.cwd(),
+    client: {},
+    project: { root: process.cwd() },
+    serverUrl: "http://localhost:3000",
+  } as unknown as PluginInput
+
+  // Capture originals so afterEach can restore
+  const originalLoomDisplayName = AGENT_DISPLAY_NAMES["loom"]!
+  const originalWeftDisplayName = AGENT_DISPLAY_NAMES["weft"]!
+  const originalLoomVariants = [...AGENT_NAME_VARIANTS["loom"]!]
+  const originalWeftVariants = [...AGENT_NAME_VARIANTS["weft"]!]
+
+  afterEach(() => {
+    // MANDATORY: Restore builtin display names mutated by createManagers during tests
+    AGENT_DISPLAY_NAMES["loom"] = originalLoomDisplayName
+    AGENT_DISPLAY_NAMES["weft"] = originalWeftDisplayName
+    // Restore name variants to prevent state leak across tests
+    AGENT_NAME_VARIANTS["loom"] = [...originalLoomVariants]
+    AGENT_NAME_VARIANTS["weft"] = [...originalWeftVariants]
+  })
+
+  it("custom display_name appears as agent key in config handler output", async () => {
+    const config = WeaveConfigSchema.parse({
+      agents: { loom: { display_name: "My Loom" } },
+    })
+    const { agents, configHandler } = createManagers({ ctx: mockCtx, pluginConfig: config })
+    const result = await configHandler.handle({ pluginConfig: config, agents })
+
+    expect(Object.keys(result.agents)).toContain("My Loom")
+    expect(Object.keys(result.agents)).not.toContain("Loom (Main Orchestrator)")
+  })
+
+  it("agents without display_name keep their default display names", async () => {
+    const config = WeaveConfigSchema.parse({
+      agents: { loom: { display_name: "My Loom" } },
+    })
+    const { agents, configHandler } = createManagers({ ctx: mockCtx, pluginConfig: config })
+    const result = await configHandler.handle({ pluginConfig: config, agents })
+
+    // Other agents are unchanged
+    expect(Object.keys(result.agents)).toContain(getAgentDisplayName("tapestry"))
+    expect(Object.keys(result.agents)).toContain(getAgentDisplayName("thread"))
+    expect(Object.keys(result.agents)).toContain(getAgentDisplayName("pattern"))
+  })
+
+  it("getAgentConfigKey resolves custom display name back to config key", async () => {
+    const config = WeaveConfigSchema.parse({
+      agents: { loom: { display_name: "My Loom" } },
+    })
+    createManagers({ ctx: mockCtx, pluginConfig: config })
+    expect(getAgentConfigKey("My Loom")).toBe("loom")
+  })
+
+  it("defaultAgent is updated to custom display name", async () => {
+    const config = WeaveConfigSchema.parse({
+      agents: { loom: { display_name: "My Loom" } },
+    })
+    const { agents, configHandler } = createManagers({ ctx: mockCtx, pluginConfig: config })
+    const result = await configHandler.handle({ pluginConfig: config, agents })
+
+    expect(result.defaultAgent).toBe("My Loom")
+  })
+
+  it("agent description is updated to match custom display name", () => {
+    const config = WeaveConfigSchema.parse({
+      agents: { weft: { display_name: "My Reviewer" } },
+    })
+    const { agents } = createManagers({ ctx: mockCtx, pluginConfig: config })
+
+    expect(agents["weft"]?.description).toBe("My Reviewer")
+  })
+
+  it("setting display_name on a disabled builtin agent does NOT crash", async () => {
+    const config = WeaveConfigSchema.parse({
+      disabled_agents: ["weft"],
+      agents: { weft: { display_name: "My Reviewer" } },
+    })
+    // Should not throw
+    const { agents, configHandler } = createManagers({ ctx: mockCtx, pluginConfig: config })
+    const result = await configHandler.handle({ pluginConfig: config, agents })
+
+    // Disabled agent should not appear in output regardless of display_name
+    expect(Object.keys(result.agents)).not.toContain("My Reviewer")
+    expect(Object.keys(result.agents)).not.toContain(originalWeftDisplayName)
+  })
+
+  it("unicode display name works end-to-end", async () => {
+    const config = WeaveConfigSchema.parse({
+      agents: { loom: { display_name: "織機 (メインオーケストレーター)" } },
+    })
+    const { agents, configHandler } = createManagers({ ctx: mockCtx, pluginConfig: config })
+    const result = await configHandler.handle({ pluginConfig: config, agents })
+
+    expect(Object.keys(result.agents)).toContain("織機 (メインオーケストレーター)")
+    expect(result.defaultAgent).toBe("織機 (メインオーケストレーター)")
   })
 })

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -4,6 +4,7 @@ import {
   getAgentDisplayName,
   getAgentConfigKey,
   registerAgentDisplayName,
+  updateBuiltinDisplayName,
 } from "./agent-display-names"
 
 describe("getAgentDisplayName", () => {
@@ -117,5 +118,69 @@ describe("registerAgentDisplayName", () => {
     expect(() =>
       registerAgentDisplayName("custom-test-agent", "My Custom Reviewer"),
     ).not.toThrow()
+  })
+})
+
+describe("updateBuiltinDisplayName", () => {
+  // Capture original values BEFORE any tests run so afterEach can restore them.
+  const originalLoomDisplayName = AGENT_DISPLAY_NAMES["loom"]!
+  const originalThreadDisplayName = AGENT_DISPLAY_NAMES["thread"]!
+
+  afterEach(() => {
+    // MANDATORY: Restore builtin display names to prevent pollution of
+    // other test suites (e.g., getAgentDisplayName tests at line 11).
+    AGENT_DISPLAY_NAMES["loom"] = originalLoomDisplayName
+    AGENT_DISPLAY_NAMES["thread"] = originalThreadDisplayName
+  })
+
+  it("updates display name for a known builtin", () => {
+    updateBuiltinDisplayName("loom", "My Loom")
+    expect(getAgentDisplayName("loom")).toBe("My Loom")
+  })
+
+  it("reverse lookup returns config key after update", () => {
+    updateBuiltinDisplayName("loom", "My Loom")
+    expect(getAgentConfigKey("My Loom")).toBe("loom")
+  })
+
+  it("old display name no longer resolves after update (cache invalidated)", () => {
+    updateBuiltinDisplayName("loom", "My Loom")
+    // The old name should not reverse-resolve to "loom" anymore
+    expect(getAgentConfigKey("Loom (Main Orchestrator)")).not.toBe("loom")
+  })
+
+  it("multiple updates to same key use last value", () => {
+    updateBuiltinDisplayName("loom", "First Name")
+    updateBuiltinDisplayName("loom", "Second Name")
+    expect(getAgentDisplayName("loom")).toBe("Second Name")
+  })
+
+  it("throws for non-builtin keys", () => {
+    expect(() => updateBuiltinDisplayName("my-custom-agent", "Custom")).toThrow(
+      /not a built-in agent/,
+    )
+  })
+
+  it("accepts unicode / CJK display names", () => {
+    updateBuiltinDisplayName("thread", "糸")
+    expect(getAgentDisplayName("thread")).toBe("糸")
+  })
+
+  it("after override, old builtin display name is still reserved for registerAgentDisplayName", () => {
+    // Override loom to "My Loom"
+    updateBuiltinDisplayName("loom", "My Loom")
+    // The original name "Loom (Main Orchestrator)" must still be reserved
+    // (INITIAL_BUILTIN_DISPLAY_NAMES prevents it from being claimed)
+    expect(() =>
+      registerAgentDisplayName("custom-test-agent", "Loom (Main Orchestrator)"),
+    ).toThrow(/reserved for built-in agent/)
+  })
+
+  it("after override, the new display name is also reserved for registerAgentDisplayName", () => {
+    updateBuiltinDisplayName("loom", "My Loom")
+    // The current (overridden) name should also be blocked
+    expect(() =>
+      registerAgentDisplayName("custom-test-agent", "My Loom"),
+    ).toThrow(/reserved for built-in agent/)
   })
 })

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -23,6 +23,19 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
 /** Built-in agent config keys — these cannot be overwritten by custom agents */
 const BUILTIN_CONFIG_KEYS = new Set(Object.keys(AGENT_DISPLAY_NAMES))
 
+/**
+ * Frozen snapshot of initial builtin display names at module load time.
+ * Used by registerAgentDisplayName() to prevent custom agents from
+ * claiming builtin display names even after they have been overridden.
+ *
+ * Example: if the user renames "loom" from "Loom (Main Orchestrator)" to "My Loom",
+ * a custom agent must NOT be allowed to claim "Loom (Main Orchestrator)" as its
+ * display name — it is still a reserved builtin name.
+ */
+const INITIAL_BUILTIN_DISPLAY_NAMES: ReadonlyMap<string, string> = new Map(
+  Object.entries(AGENT_DISPLAY_NAMES),
+)
+
 /** Lazily-computed reverse lookup (display name → config key). Invalidated on registration. */
 let reverseDisplayNames: Record<string, string> | null = null
 
@@ -51,6 +64,16 @@ export function registerAgentDisplayName(configKey: string, displayName: string)
   }
 
   // Prevent custom agents from claiming a builtin agent's display name
+  // Check against INITIAL_BUILTIN_DISPLAY_NAMES (frozen snapshot) so that
+  // even after a builtin display name is overridden, its original name stays reserved.
+  for (const [builtinKey, initialDisplayName] of INITIAL_BUILTIN_DISPLAY_NAMES) {
+    if (initialDisplayName.toLowerCase() === displayName.toLowerCase()) {
+      throw new Error(
+        `Display name "${displayName}" is reserved for built-in agent "${builtinKey}"`,
+      )
+    }
+  }
+  // Also check current (potentially overridden) display names in the mutable map
   const reverse = getReverseDisplayNames()
   const existingKey = reverse[displayName.toLowerCase()]
   if (existingKey !== undefined && BUILTIN_CONFIG_KEYS.has(existingKey)) {
@@ -59,6 +82,24 @@ export function registerAgentDisplayName(configKey: string, displayName: string)
     )
   }
 
+  AGENT_DISPLAY_NAMES[configKey] = displayName
+  reverseDisplayNames = null // invalidate cache
+}
+
+/**
+ * Override the display name for a built-in agent.
+ * Unlike registerAgentDisplayName (which guards against builtin config keys),
+ * this function is specifically for user-configured builtin display names.
+ *
+ * Only accepts known builtin config keys. Throws for unknown keys.
+ * Invalidates the reverse lookup cache so getAgentConfigKey reflects the new name.
+ */
+export function updateBuiltinDisplayName(configKey: string, displayName: string): void {
+  if (!BUILTIN_CONFIG_KEYS.has(configKey)) {
+    throw new Error(
+      `Cannot update builtin display name for "${configKey}": not a built-in agent`,
+    )
+  }
   AGENT_DISPLAY_NAMES[configKey] = displayName
   reverseDisplayNames = null // invalidate cache
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -7,4 +7,5 @@ export {
   getAgentDisplayName,
   getAgentConfigKey,
   registerAgentDisplayName,
+  updateBuiltinDisplayName,
 } from "./agent-display-names"


### PR DESCRIPTION
## Summary

Allow users to override builtin agent display names (Loom, Thread, Pattern, Shuttle, Spindle, Weft, Warp) via the `display_name` field in `weave-opencode.jsonc` agent overrides. This enables localization, personalization, and theming of agent names throughout the UI and prompt system.

## Usage

Add `display_name` to any builtin agent override in your `weave-opencode.jsonc`:

### 🇯🇵 Japanese — Weaving Theme

```jsonc
{
  "agents": {
    "loom": { "display_name": "織機 (メインオーケストレーター)" },
    "thread": { "display_name": "糸 (コード探索)" },
    "pattern": { "display_name": "型紙 (設計プランナー)" },
    "shuttle": { "display_name": "杼 (ドメイン専門家)" },
    "spindle": { "display_name": "紡錘 (外部リサーチ)" },
    "weft": { "display_name": "横糸 (レビュアー)" },
    "warp": { "display_name": "経糸 (セキュリティ)" }
  }
}
```

### 🏴‍☠️ Pirate Crew

```jsonc
{
  "agents": {
    "loom": { "display_name": "Captain" },
    "thread": { "display_name": "Lookout" },
    "pattern": { "display_name": "Navigator" },
    "shuttle": { "display_name": "Quartermaster" },
    "spindle": { "display_name": "Scout" },
    "weft": { "display_name": "First Mate" },
    "warp": { "display_name": "Gunner" }
  }
}
```

### 🧙 Fantasy RPG Party

```jsonc
{
  "agents": {
    "loom": { "display_name": "Archmage" },
    "thread": { "display_name": "Ranger" },
    "pattern": { "display_name": "Strategist" },
    "shuttle": { "display_name": "Artificer" },
    "spindle": { "display_name": "Oracle" },
    "weft": { "display_name": "Paladin" },
    "warp": { "display_name": "Sentinel" }
  }
}
```

### 🔬 Minimal — Just Rename One

```jsonc
{
  "agents": {
    "loom": { "display_name": "Coordinator" }
  }
}
```

Display names appear in the UI header, agent responses, and are used for prompt routing. The original agent key (`loom`, `thread`, etc.) is always used for configuration — `display_name` only affects what's shown to you.

## What Changed

- **`src/config/schema.ts`** — Added `display_name: z.string().optional()` to `AgentOverrideConfigSchema`
- **`src/shared/agent-display-names.ts`** — Added `INITIAL_BUILTIN_DISPLAY_NAMES` frozen snapshot, `updateBuiltinDisplayName()` with collision guards
- **`src/shared/index.ts`** — Re-exported `updateBuiltinDisplayName`
- **`src/agents/agent-builder.ts`** — Added `addBuiltinNameVariant()`, exported `AGENT_NAME_VARIANTS`, switched regex from `\b...\b` to `(?<!\w)...(?!\w)` for Unicode support
- **`src/create-managers.ts`** — Wires `display_name` overrides between builtin agent creation and config handler at startup
- **`docs/configuration.md`** — Documented the feature in schema reference and Agent Names section

## Tests

19 new tests across 3 files (8 unit + 4 unit + 7 integration):

- **`agent-display-names.test.ts`** — `updateBuiltinDisplayName` override, revert, collision, non-builtin rejection
- **`agent-builder.test.ts`** — `addBuiltinNameVariant` registration, stripping with Unicode display names
- **`integration.test.ts`** — End-to-end: disabled+display_name, Unicode names, collision rejection, state cleanup

All 1265 tests pass. Build is clean.