### PR TITLE
fix(agents): forward modelOptions to runtime options

### DIFF
--- a/src/agents/builtin-agents.test.ts
+++ b/src/agents/builtin-agents.test.ts
@@ -52,6 +52,24 @@ describe("createBuiltinAgents", () => {
     expect(agents["loom"]?.temperature).toBe(0.3)
   })
 
+  it("applies modelOptions override to builtin subagents", () => {
+    const agents = createBuiltinAgents({
+      agentOverrides: {
+        pattern: {
+          modelOptions: {
+            reasoningEffort: "high",
+            reasoning: { effort: "medium" },
+          },
+        },
+      },
+    })
+    const pattern = agents["pattern"] as { options?: Record<string, unknown> } | undefined
+    expect(pattern?.options).toEqual({
+      reasoningEffort: "high",
+      reasoning: { effort: "medium" },
+    })
+  })
+
   it("resolves override skills and prepends them to the agent prompt", () => {
     const agents = createBuiltinAgents({
       agentOverrides: { pattern: { skills: ["test-skill"] } },

--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -17,6 +17,10 @@ import type { ProjectFingerprint } from "../features/analytics/types"
 import type { AvailableAgent } from "./dynamic-prompt-builder"
 import { debug } from "../shared/log"
 
+type AgentConfigWithOptions = AgentConfig & {
+  options?: Record<string, unknown>
+}
+
 export interface CreateBuiltinAgentsOptions {
   disabledAgents?: string[]
   agentOverrides?: Record<string, AgentOverrideConfig>
@@ -215,7 +219,7 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
 
     // Use prompt-composer-aware constructors for loom and tapestry
     // so their prompts conditionally omit references to disabled agents
-    let built: AgentConfig
+    let built: AgentConfigWithOptions
     if (name === "loom") {
       built = createLoomAgentWithOptions(resolvedModel, disabledSet, fingerprint, customAgentMetadata)
     } else if (name === "tapestry") {
@@ -241,6 +245,9 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
       }
       if (override.temperature !== undefined) {
         built.temperature = override.temperature
+      }
+      if (override.modelOptions !== undefined) {
+        built.options = override.modelOptions
       }
     }
 

--- a/src/agents/custom-agent-factory.test.ts
+++ b/src/agents/custom-agent-factory.test.ts
@@ -95,6 +95,24 @@ describe("buildCustomAgent", () => {
     expect(agent.top_p).toBe(0.9)
   })
 
+  it("passes through modelOptions", () => {
+    const config: CustomAgentConfig = {
+      prompt: "Test.",
+      model: "test-model/v1",
+      modelOptions: {
+        reasoningEffort: "medium",
+        reasoning: { effort: "high" },
+      },
+    }
+    const agent = buildCustomAgent("test-agent", config) as {
+      options?: Record<string, unknown>
+    }
+    expect(agent.options).toEqual({
+      reasoningEffort: "medium",
+      reasoning: { effort: "high" },
+    })
+  })
+
   it("applies tool permissions", () => {
     const config: CustomAgentConfig = {
       prompt: "Test.",

--- a/src/agents/custom-agent-factory.ts
+++ b/src/agents/custom-agent-factory.ts
@@ -9,6 +9,10 @@ import { registerAgentDisplayName } from "../shared/agent-display-names"
 import { registerAgentNameVariants } from "./agent-builder"
 import { debug } from "../shared/log"
 
+type AgentConfigWithOptions = AgentConfig & {
+  options?: Record<string, unknown>
+}
+
 /** Known tool names that can be granted/denied via config */
 const KNOWN_TOOL_NAMES = new Set([
   "write",
@@ -123,7 +127,7 @@ export function buildCustomAgent(
   })
 
   // Build the agent config
-  const agentConfig: AgentConfig = {
+  const agentConfig: AgentConfigWithOptions = {
     model,
     prompt: prompt || undefined,
     description: config.description ?? displayName,
@@ -133,6 +137,7 @@ export function buildCustomAgent(
   if (config.temperature !== undefined) agentConfig.temperature = config.temperature
   if (config.top_p !== undefined) agentConfig.top_p = config.top_p
   if (config.maxTokens !== undefined) agentConfig.maxTokens = config.maxTokens
+  if (config.modelOptions !== undefined) agentConfig.options = config.modelOptions
   if (config.tools) {
     // Validate tool names against known allowlist
     const unknownTools = Object.keys(config.tools).filter((t) => !KNOWN_TOOL_NAMES.has(t))

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -17,6 +17,26 @@ describe("WeaveConfigSchema", () => {
     }
   })
 
+  it("parses agent override modelOptions passthrough", () => {
+    const result = WeaveConfigSchema.safeParse({
+      agents: {
+        loom: {
+          modelOptions: {
+            reasoningEffort: "medium",
+            reasoning: { effort: "high" },
+          },
+        },
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.agents?.loom?.modelOptions).toEqual({
+        reasoningEffort: "medium",
+        reasoning: { effort: "high" },
+      })
+    }
+  })
+
   it("rejects invalid temperature value (>2)", () => {
     const result = WeaveConfigSchema.safeParse({
       agents: { loom: { temperature: 5.0 } },
@@ -46,6 +66,28 @@ describe("WeaveConfigSchema", () => {
       categories: { deep: { model: "claude-opus-4", temperature: 0.5 } },
     })
     expect(result.success).toBe(true)
+  })
+
+  it("parses custom agent modelOptions passthrough", () => {
+    const result = WeaveConfigSchema.safeParse({
+      custom_agents: {
+        reviewer: {
+          prompt: "Review code.",
+          model: "claude-opus-4",
+          modelOptions: {
+            reasoningEffort: "low",
+            reasoning: { budgetTokens: 2048 },
+          },
+        },
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.custom_agents?.reviewer?.modelOptions).toEqual({
+        reasoningEffort: "low",
+        reasoning: { budgetTokens: 2048 },
+      })
+    }
   })
 
   it("parses background config with concurrency limits", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -11,6 +11,8 @@ const SafeRelativePathSchema = z.string().refine(
   { message: "Directory paths must be relative and must not contain '..' segments" },
 )
 
+const ModelOptionsSchema = z.record(z.string(), z.unknown())
+
 export const AgentOverrideConfigSchema = z.object({
   model: z.string().optional(),
   fallback_models: z.array(z.string()).optional(),
@@ -22,6 +24,7 @@ export const AgentOverrideConfigSchema = z.object({
   prompt: z.string().optional(),
   prompt_append: z.string().optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
+  modelOptions: ModelOptionsSchema.optional(),
   disable: z.boolean().optional(),
   mode: z.enum(["subagent", "primary", "all"]).optional(),
   maxTokens: z.number().optional(),
@@ -95,6 +98,8 @@ export const CustomAgentConfigSchema = z.object({
   top_p: z.number().min(0).max(1).optional(),
   /** Max tokens */
   maxTokens: z.number().optional(),
+  /** Provider/model-specific passthrough options (e.g. reasoningEffort, reasoning) */
+  modelOptions: ModelOptionsSchema.optional(),
   /** Tool permissions (true = enabled, false = denied) */
   tools: z.record(z.string(), z.boolean()).optional(),
   /** Skills to load for this agent */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `modelOptions` in agent overrides and custom agent configurations, allowing users to specify provider-specific model parameters (such as reasoning effort levels and budget tokens) at the agent level.

* **Tests**
  * Added comprehensive test coverage validating `modelOptions` handling in builtin agents, custom agents, and configuration schema parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->