### PR TITLE
feat(review): add opt-in multi-reviewer workflow

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ flowchart LR
 
 - **Nested objects** (agents, categories): deep merge — project keys override user keys recursively
 - **Arrays** (disabled_*): union with deduplication — both sets combined
+- **`review`**: deep merge, except `review.additional_agents` is **project-overrides-user** (no union) so projects can clear inherited reviewers with `[]`
 - **Scalars**: project value wins over user value
 
 ## Full Schema
@@ -124,9 +125,24 @@ The generated JSON Schema above is the authoritative contract for editor tooling
     "plugin_load_timeout_ms": 5000,
     "context_window_warning_threshold": 0.8,
     "context_window_critical_threshold": 0.95
+  },
+
+  // Additional reviewers for review flows.
+  // Values reference keys from `custom_agents`.
+  "review": {
+    "additional_agents": ["security-reviewer", "perf-reviewer"]
   }
 }
 ```
+
+### `review.additional_agents`
+
+- Type: `string[]`
+- Meaning: list of **custom agent names** (keys under `custom_agents`) that should be used as additional reviewers.
+- Default-safe behavior:
+  - If `review` is omitted: behavior is unchanged from today.
+  - If `review.additional_agents` is omitted: behavior is unchanged from today.
+  - If `review.additional_agents` is `[]`: project config intentionally disables inherited additional reviewers.
 
 ## Agent Names
 

--- a/evals/cases/loom/review-workflow-contract.jsonc
+++ b/evals/cases/loom/review-workflow-contract.jsonc
@@ -1,6 +1,6 @@
 {
   "id": "loom-review-workflow-contract",
-  "title": "Loom review workflow remains mandatory when reviewers are enabled",
+  "title": "Loom legacy review workflow preserves ad-hoc synthesis and /start-work handoff",
   "phase": "prompt",
   "tags": ["prompt", "composer", "loom", "review"],
   "target": {
@@ -12,7 +12,8 @@
   },
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["ReviewWorkflow"] },
-    { "kind": "section-contains-all", "section": "ReviewWorkflow", "patterns": ["Warp is mandatory", "Ad-hoc review"] },
-    { "kind": "section-contains-all", "section": "PlanWorkflow", "patterns": ["Delegate to Pattern", "Delegate to Weft", "/start-work"] }
+    { "kind": "section-contains-all", "section": "ReviewWorkflow", "patterns": ["Ad-hoc review (outside of plan execution):", "Delegate to Weft", "Collection phase", "Comparison phase", "Synthesis phase", "consensus", "discrepancies", "unique findings", "Do not hide rejections or minority findings", "Escalate real reviewer disagreements to the user", "Warp is mandatory"] },
+    { "kind": "section-contains-all", "section": "PlanWorkflow", "patterns": ["Delegate to Pattern", "Delegate to Weft (primary reviewer)", "Collection phase", "Comparison phase", "Synthesis phase", "Tell the user to run `/start-work` — Tapestry handles execution", "`/start-work` also resumes interrupted work"] },
+    { "kind": "excludes-all", "patterns": ["review.additional_agents", "Delegate to Custom Reviewer", "subagent_type \"review-custom\""] }
   ]
 }

--- a/evals/cases/tapestry/disabled-reviewers-contract.jsonc
+++ b/evals/cases/tapestry/disabled-reviewers-contract.jsonc
@@ -1,8 +1,8 @@
 {
   "id": "tapestry-disabled-reviewers-contract",
-  "title": "Tapestry removes delegated review when Weft and Warp are disabled",
+  "title": "Tapestry legacy fallback removes delegated review when all reviewers are disabled",
   "phase": "prompt",
-  "tags": ["prompt", "composer", "tapestry", "variants"],
+  "tags": ["prompt", "composer", "tapestry", "variants", "legacy", "review"],
   "target": {
     "kind": "builtin-agent-prompt",
     "agent": "tapestry",
@@ -15,7 +15,7 @@
   },
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
-    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Identify all changed files", "Report the summary of all changes to the user."] },
-    { "kind": "excludes-all", "patterns": ["subagent_type \"weft\"", "subagent_type \"warp\"", "Delegate to"] }
+    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["This section applies only after ALL plan tasks are already checked off.", "Do not mention this section while any unchecked task remains.", "After ALL plan tasks are checked off:", "Identify all changed files", "Report the summary of all changes to the user."] },
+    { "kind": "excludes-all", "patterns": ["subagent_type \"weft\"", "subagent_type \"warp\"", "review.additional_agents", "Delegate to"] }
   ]
 }

--- a/evals/cases/tapestry/multi-reviewers-contract.jsonc
+++ b/evals/cases/tapestry/multi-reviewers-contract.jsonc
@@ -1,0 +1,45 @@
+{
+  "id": "tapestry-multi-reviewers-contract",
+  "title": "Tapestry PostExecutionReview runs Weft plus additional reviewers and Warp with structured synthesis",
+  "phase": "prompt",
+  "tags": ["prompt", "composer", "tapestry", "variants", "review"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "tapestry",
+    "variant": {
+      "additionalReviewers": [
+        {
+          "key": "review-custom",
+          "label": "Custom Reviewer",
+          "source": "custom"
+        }
+      ]
+    }
+  },
+  "executor": {
+    "kind": "prompt-render"
+  },
+  "evaluators": [
+    { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
+    {
+      "kind": "section-contains-all",
+      "section": "PostExecutionReview",
+      "patterns": [
+        "Delegate to Weft",
+        "subagent_type \"weft\"",
+        "Delegate to Custom Reviewer",
+        "subagent_type \"review-custom\"",
+        "review.additional_agents",
+        "Delegate to Warp",
+        "subagent_type \"warp\"",
+        "independent reviewers MAY run as parallel Task calls",
+        "final sequential synthesis",
+        "Consensus",
+        "Discrepancies",
+        "Unique findings",
+        "Do NOT average results",
+        "Do NOT discard minority or isolated findings"
+      ]
+    }
+  ]
+}

--- a/evals/cases/tapestry/routing/route-to-reviewers-post-execution-multi.jsonc
+++ b/evals/cases/tapestry/routing/route-to-reviewers-post-execution-multi.jsonc
@@ -1,0 +1,33 @@
+{
+  "id": "route-to-reviewers-post-execution-multi",
+  "title": "Tapestry routes to Weft, opt-in reviewer, and Warp after completing all plan tasks",
+  "description": "Verifies that with additional reviewers configured, Tapestry routes terminal review through Weft, the configured reviewer, and Warp before any final completion message.",
+  "phase": "routing",
+  "tags": ["routing", "tapestry", "review", "post-execution", "multi-reviewer"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "tapestry",
+    "variant": {
+      "additionalReviewers": [
+        {
+          "key": "shuttle",
+          "label": "Shuttle Reviewer",
+          "source": "custom"
+        }
+      ]
+    }
+  },
+  "executor": {
+    "kind": "model-response",
+    "provider": "openrouter",
+    "model": "openai/gpt-5.4",
+    "input": "All 5 plan tasks are now checked off (5/5 complete). The changed files from git diff are: src/auth/handler.ts, src/auth/middleware.ts, src/models/user.ts, src/routes/auth.ts, tests/auth.test.ts. What should I do now?"
+  },
+  "evaluators": [
+    {
+      "kind": "llm-judge",
+      "expectedContains": ["weft", "shuttle", "warp", "review"],
+      "forbiddenContains": ["plan execution is complete without review"]
+    }
+  ]
+}

--- a/evals/cases/tapestry/routing/route-to-reviewers-post-execution-multi.jsonc
+++ b/evals/cases/tapestry/routing/route-to-reviewers-post-execution-multi.jsonc
@@ -10,7 +10,7 @@
     "variant": {
       "additionalReviewers": [
         {
-          "key": "shuttle",
+          "key": "review-shuttle",
           "label": "Shuttle Reviewer",
           "source": "custom"
         }
@@ -26,7 +26,7 @@
   "evaluators": [
     {
       "kind": "llm-judge",
-      "expectedContains": ["weft", "shuttle", "warp", "review"],
+      "expectedContains": ["weft", "review-shuttle", "warp", "review"],
       "forbiddenContains": ["plan execution is complete without review"]
     }
   ]

--- a/evals/cases/tapestry/warp-only-review-contract.jsonc
+++ b/evals/cases/tapestry/warp-only-review-contract.jsonc
@@ -1,8 +1,8 @@
 {
   "id": "tapestry-warp-only-review-contract",
-  "title": "Tapestry PostExecutionReview delegates to Warp only when Weft is disabled",
+  "title": "Tapestry legacy PostExecutionReview delegates to Warp only when Weft is disabled",
   "phase": "prompt",
-  "tags": ["prompt", "composer", "tapestry", "variants"],
+  "tags": ["prompt", "composer", "tapestry", "variants", "legacy", "review"],
   "target": {
     "kind": "builtin-agent-prompt",
     "agent": "tapestry",
@@ -15,7 +15,7 @@
   },
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
-    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Delegate to Warp", "subagent_type \"warp\"", "Task tool"] },
-    { "kind": "excludes-all", "patterns": ["subagent_type \"weft\""] }
+    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["This section applies only when no unchecked plan tasks remain.", "Ignore this section completely while any unchecked task remains.", "When all plan tasks are checked off:", "Delegate to Warp", "subagent_type \"warp\"", "Task tool", "Consensus", "Discrepancies", "Unique findings", "Do NOT average results"] },
+    { "kind": "excludes-all", "patterns": ["subagent_type \"weft\"", "review.additional_agents", "Delegate to Custom Reviewer", "subagent_type \"review-custom\""] }
   ]
 }

--- a/evals/cases/tapestry/weft-only-review-contract.jsonc
+++ b/evals/cases/tapestry/weft-only-review-contract.jsonc
@@ -1,8 +1,8 @@
 {
   "id": "tapestry-weft-only-review-contract",
-  "title": "Tapestry PostExecutionReview delegates to Weft only when Warp is disabled",
+  "title": "Tapestry legacy PostExecutionReview delegates to Weft only when Warp is disabled",
   "phase": "prompt",
-  "tags": ["prompt", "composer", "tapestry", "variants"],
+  "tags": ["prompt", "composer", "tapestry", "variants", "legacy", "review"],
   "target": {
     "kind": "builtin-agent-prompt",
     "agent": "tapestry",
@@ -15,7 +15,7 @@
   },
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
-    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Delegate to Weft", "subagent_type \"weft\"", "Task tool"] },
-    { "kind": "excludes-all", "patterns": ["subagent_type \"warp\""] }
+    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["This section applies only when no unchecked plan tasks remain.", "Ignore this section completely while any unchecked task remains.", "When all plan tasks are checked off:", "Delegate to Weft", "subagent_type \"weft\"", "Task tool", "Consensus", "Discrepancies", "Unique findings", "Do NOT average results"] },
+    { "kind": "excludes-all", "patterns": ["subagent_type \"warp\"", "review.additional_agents", "Delegate to Custom Reviewer", "subagent_type \"review-custom\""] }
   ]
 }

--- a/evals/cases/trajectory/tapestry-post-execution-review-multi.jsonc
+++ b/evals/cases/trajectory/tapestry-post-execution-review-multi.jsonc
@@ -1,0 +1,33 @@
+{
+  "id": "trajectory-tapestry-post-execution-review-multi",
+  "title": "Trajectory: Tapestry delegates to Weft, opt-in reviewer, and Warp for post-execution review",
+  "description": "Checks the post-execution review chain where Tapestry routes completed work through Weft, an opt-in configured reviewer, and Warp before reporting final review status.",
+  "phase": "trajectory",
+  "tags": ["trajectory", "tapestry", "weft", "shuttle", "warp", "delegation", "review", "multi-reviewer"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "tapestry",
+    "variant": {
+      "additionalReviewers": [
+        {
+          "key": "shuttle",
+          "label": "Shuttle Reviewer",
+          "source": "custom"
+        }
+      ]
+    }
+  },
+  "executor": {
+    "kind": "trajectory-run",
+    "scenarioRef": "evals/scenarios/tapestry-post-execution-review-multi.jsonc"
+  },
+  "evaluators": [
+    {
+      "kind": "trajectory-assertion",
+      "expectedSequence": ["tapestry", "weft", "tapestry", "shuttle", "tapestry", "warp", "tapestry"],
+      "requiredAgents": ["weft", "shuttle", "warp"],
+      "expectedDelegationTargets": ["weft", "shuttle", "warp"],
+      "minTurns": 8
+    }
+  ]
+}

--- a/evals/scenarios/tapestry-post-execution-review-multi.jsonc
+++ b/evals/scenarios/tapestry-post-execution-review-multi.jsonc
@@ -1,0 +1,65 @@
+{
+  "id": "tapestry-post-execution-review-multi",
+  "title": "Tapestry delegates to Weft, Shuttle Reviewer, and Warp after completing all plan tasks",
+  "description": "Tapestry finishes all plan tasks, then delegates to Weft, a configured additional reviewer, and Warp as a mandatory terminal review gate before reporting final status.",
+  "agents": ["tapestry", "weft", "shuttle", "warp"],
+  "turns": [
+    {
+      "turn": 1,
+      "role": "user",
+      "content": "All plan tasks are now checked off. The changed files are: src/auth/handler.ts, src/auth/middleware.ts, src/models/user.ts, src/routes/auth.ts, tests/auth.test.ts."
+    },
+    {
+      "turn": 2,
+      "role": "assistant",
+      "agent": "tapestry",
+      "content": "All tasks complete. Running mandatory post-execution review with Weft, Shuttle Reviewer, and Warp.",
+      "expectedDelegation": "weft",
+      "mockResponse": "All 5 plan tasks are checked off. Running the mandatory post-execution review gate.\n\nChanged files identified:\n- src/auth/handler.ts\n- src/auth/middleware.ts\n- src/models/user.ts\n- src/routes/auth.ts\n- tests/auth.test.ts\n\n*Delegating to Weft for primary quality review...*"
+    },
+    {
+      "turn": 3,
+      "role": "assistant",
+      "agent": "weft",
+      "content": "Weft reviews the changes for code quality.",
+      "mockResponse": "## Code Quality Review\n\n**[APPROVE]**\n\n**Summary**: Changes are coherent and maintainable. Tests cover key flows and error handling."
+    },
+    {
+      "turn": 4,
+      "role": "assistant",
+      "agent": "tapestry",
+      "content": "Weft returned. Delegating independent additional review to Shuttle Reviewer.",
+      "expectedDelegation": "shuttle",
+      "mockResponse": "Received Weft output.\n\n*Delegating to Shuttle Reviewer for independent additional review...*"
+    },
+    {
+      "turn": 5,
+      "role": "assistant",
+      "agent": "shuttle",
+      "content": "Shuttle Reviewer performs an additional independent review.",
+      "mockResponse": "## Additional Reviewer (Shuttle)\n\n**[APPROVE]**\n\n**Summary**: No blocking implementation concerns found. Naming and boundaries are consistent with surrounding modules."
+    },
+    {
+      "turn": 6,
+      "role": "assistant",
+      "agent": "tapestry",
+      "content": "Additional reviewer returned. Delegating security audit to Warp.",
+      "expectedDelegation": "warp",
+      "mockResponse": "Received Shuttle Reviewer output.\n\n*Delegating to Warp for security audit...*"
+    },
+    {
+      "turn": 7,
+      "role": "assistant",
+      "agent": "warp",
+      "content": "Warp audits the security aspects of the changes.",
+      "mockResponse": "## Security Audit\n\n**[APPROVE]**\n\n**Summary**: Auth-related paths follow secure handling. No vulnerabilities detected in this diff scope."
+    },
+    {
+      "turn": 8,
+      "role": "assistant",
+      "agent": "tapestry",
+      "content": "All reviewers responded. Reporting final synthesis.",
+      "mockResponse": "Post-execution review complete:\n\n- **Weft**: APPROVED\n- **Shuttle Reviewer**: APPROVED\n- **Warp**: APPROVED\n\nConsensus: no blockers.\nDiscrepancies: none.\nUnique findings: none.\n\nAll tasks executed and reviewed successfully."
+    }
+  ]
+}

--- a/evals/suites/prompt-contracts.jsonc
+++ b/evals/suites/prompt-contracts.jsonc
@@ -17,6 +17,7 @@
     "evals/cases/shuttle/default-contract.jsonc",
     "evals/cases/tapestry/weft-only-review-contract.jsonc",
     "evals/cases/tapestry/warp-only-review-contract.jsonc",
+    "evals/cases/tapestry/multi-reviewers-contract.jsonc",
     "evals/cases/loom/plan-review-scoped-contract.jsonc"
   ]
 }

--- a/evals/suites/tapestry-review-routing.jsonc
+++ b/evals/suites/tapestry-review-routing.jsonc
@@ -1,6 +1,6 @@
 {
   "id": "tapestry-review-routing",
-  "title": "Tapestry post-execution review routing",
+  "title": "Tapestry post-execution review routing (legacy + multi-reviewer)",
   "phase": "routing",
   "suiteMetadata": {
     "title": "Tapestry Review Routing",
@@ -12,6 +12,7 @@
   },
   "tags": ["routing", "tapestry", "review", "judge"],
   "caseFiles": [
-    "evals/cases/tapestry/routing/route-to-reviewers-post-execution.jsonc"
+    "evals/cases/tapestry/routing/route-to-reviewers-post-execution.jsonc",
+    "evals/cases/tapestry/routing/route-to-reviewers-post-execution-multi.jsonc"
   ]
 }

--- a/evals/suites/tapestry-review-trajectory.jsonc
+++ b/evals/suites/tapestry-review-trajectory.jsonc
@@ -1,6 +1,6 @@
 {
   "id": "tapestry-review-trajectory",
-  "title": "Tapestry post-execution review trajectory",
+  "title": "Tapestry post-execution review trajectory (legacy + multi-reviewer)",
   "phase": "trajectory",
   "suiteMetadata": {
     "title": "Tapestry Review Trajectory",
@@ -12,6 +12,7 @@
   },
   "tags": ["trajectory", "tapestry", "review"],
   "caseFiles": [
-    "evals/cases/trajectory/tapestry-post-execution-review.jsonc"
+    "evals/cases/trajectory/tapestry-post-execution-review.jsonc",
+    "evals/cases/trajectory/tapestry-post-execution-review-multi.jsonc"
   ]
 }

--- a/schema/weave-config.schema.json
+++ b/schema/weave-config.schema.json
@@ -340,6 +340,18 @@
           },
           "additionalProperties": false
         },
+        "review": {
+          "type": "object",
+          "properties": {
+            "additional_agents": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "continuation": {
           "type": "object",
           "properties": {

--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -16,6 +16,7 @@ import type { ResolveSkillsFn } from "./agent-builder"
 import type { ProjectFingerprint } from "../features/analytics/types"
 import type { AvailableAgent } from "./dynamic-prompt-builder"
 import { debug } from "../shared/log"
+import type { ResolvedReviewer } from "../review/reviewer-resolution"
 
 type AgentConfigWithOptions = AgentConfig & {
   options?: Record<string, unknown>
@@ -34,6 +35,8 @@ export interface CreateBuiltinAgentsOptions {
   fingerprint?: ProjectFingerprint | null
   /** Custom agent metadata for Loom's dynamic delegation prompt */
   customAgentMetadata?: AvailableAgent[]
+  /** Effective extra reviewers configured in review.additional_agents */
+  additionalReviewers?: ResolvedReviewer[]
   /** Resolved continuation config for prompt-aware agents */
   continuation?: ResolvedContinuationConfig
 }
@@ -189,6 +192,7 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
     resolveSkills,
     fingerprint,
     customAgentMetadata,
+    additionalReviewers = [],
     continuation,
   } = options
 
@@ -221,9 +225,16 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
     // so their prompts conditionally omit references to disabled agents
     let built: AgentConfigWithOptions
     if (name === "loom") {
-      built = createLoomAgentWithOptions(resolvedModel, disabledSet, fingerprint, customAgentMetadata, categories)
+      built = createLoomAgentWithOptions(
+        resolvedModel,
+        disabledSet,
+        fingerprint,
+        customAgentMetadata,
+        categories,
+        additionalReviewers,
+      )
     } else if (name === "tapestry") {
-      built = createTapestryAgentWithOptions(resolvedModel, disabledSet, continuation, categories)
+      built = createTapestryAgentWithOptions(resolvedModel, disabledSet, continuation, categories, additionalReviewers)
     } else {
       built = buildAgent(factory, resolvedModel, {
         categories,

--- a/src/agents/loom/index.test.ts
+++ b/src/agents/loom/index.test.ts
@@ -55,8 +55,22 @@ describe("createLoomAgent", () => {
       prompt.indexOf("</PlanWorkflow>"),
     )
     expect(planWorkflow).toContain("REVIEW")
-    expect(planWorkflow).toContain("Weft")
+    expect(planWorkflow).toContain("Weft (primary reviewer)")
     expect(planWorkflow).toContain("Warp")
+  })
+
+  it("PlanWorkflow requires structured multi-review synthesis", () => {
+    const config = createLoomAgent("claude-opus-4")
+    const prompt = config.prompt as string
+    const planWorkflow = prompt.slice(
+      prompt.indexOf("<PlanWorkflow>"),
+      prompt.indexOf("</PlanWorkflow>"),
+    )
+    expect(planWorkflow).toContain("Collection phase")
+    expect(planWorkflow).toContain("Comparison phase")
+    expect(planWorkflow).toContain("consensus")
+    expect(planWorkflow).toContain("discrepancies")
+    expect(planWorkflow).toContain("unique findings")
   })
 
   it("ReviewWorkflow contains Warp mandatory language", () => {
@@ -134,6 +148,17 @@ describe("createLoomAgent", () => {
     expect(reviewWorkflow).toContain("Weft")
     expect(reviewWorkflow).not.toContain("Post-Plan")
   })
+
+  it("ReviewWorkflow forbids hiding minority findings", () => {
+    const config = createLoomAgent("claude-opus-4")
+    const prompt = config.prompt as string
+    const reviewWorkflow = prompt.slice(
+      prompt.indexOf("<ReviewWorkflow>"),
+      prompt.indexOf("</ReviewWorkflow>"),
+    )
+    expect(reviewWorkflow).toContain("Do not hide rejections or minority findings")
+    expect(reviewWorkflow).toContain("Escalate real reviewer disagreements to the user")
+  })
 })
 
 describe("createLoomAgentWithOptions", () => {
@@ -160,6 +185,30 @@ describe("createLoomAgentWithOptions", () => {
   it("returns default prompt with empty custom agents array", () => {
     const config = createLoomAgentWithOptions("claude-opus-4", undefined, null, [])
     expect(config.prompt).not.toContain("<CustomDelegation>")
+  })
+
+  it("preserves legacy prompt when additional reviewers are omitted or empty", () => {
+    const legacy = createLoomAgent("claude-opus-4")
+    const withoutReviewers = createLoomAgentWithOptions("claude-opus-4")
+    const withEmptyReviewers = createLoomAgentWithOptions("claude-opus-4", undefined, null, undefined, undefined, [])
+
+    expect(withoutReviewers.prompt).toBe(legacy.prompt)
+    expect(withEmptyReviewers.prompt).toBe(legacy.prompt)
+  })
+
+  it("includes additional reviewers when provided", () => {
+    const config = createLoomAgentWithOptions(
+      "claude-opus-4",
+      undefined,
+      null,
+      undefined,
+      undefined,
+      [{ key: "review-custom", label: "Custom Reviewer", source: "custom", isValid: true }],
+    )
+
+    expect(config.prompt).toContain("Weft (primary reviewer)")
+    expect(config.prompt).toContain("Custom Reviewer (subagent_type \"review-custom\")")
+    expect(config.prompt).toContain("Collection phase")
   })
 
   it("includes multiple custom agents in delegation table", () => {

--- a/src/agents/loom/index.ts
+++ b/src/agents/loom/index.ts
@@ -3,6 +3,7 @@ import type { AgentFactory } from "../types"
 import type { AvailableAgent } from "../dynamic-prompt-builder"
 import type { ProjectFingerprint } from "../../features/analytics/types"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ResolvedReviewer } from "../../review/reviewer-resolution"
 import { LOOM_DEFAULTS } from "./default"
 import { composeLoomPrompt } from "./prompt-composer"
 
@@ -18,13 +19,24 @@ export function createLoomAgentWithOptions(
   fingerprint?: ProjectFingerprint | null,
   customAgents?: AvailableAgent[],
   categories?: CategoriesConfig,
+  additionalReviewers: ResolvedReviewer[] = [],
 ): AgentConfig {
-  if ((!disabledAgents || disabledAgents.size === 0) && !fingerprint && (!customAgents || customAgents.length === 0) && !categories) {
+  const hasAdditionalReviewers = additionalReviewers.length > 0
+  if ((!disabledAgents || disabledAgents.size === 0) && !fingerprint && (!customAgents || customAgents.length === 0) && !categories && !hasAdditionalReviewers) {
     return { ...LOOM_DEFAULTS, model, mode: "primary" }
   }
+
+  const prompt = composeLoomPrompt({
+    disabledAgents,
+    fingerprint,
+    customAgents,
+    categories,
+    additionalReviewers,
+  })
+
   return {
     ...LOOM_DEFAULTS,
-    prompt: composeLoomPrompt({ disabledAgents, fingerprint, customAgents, categories }),
+    prompt,
     model,
     mode: "primary",
   }

--- a/src/agents/loom/prompt-composer.test.ts
+++ b/src/agents/loom/prompt-composer.test.ts
@@ -139,6 +139,10 @@ describe("buildDelegationSection", () => {
 })
 
 describe("buildPlanWorkflowSection", () => {
+  const additionalReviewers = [
+    { key: "review-custom", label: "Custom Reviewer", source: "custom" as const, isValid: true },
+  ]
+
   it("contains plan routing statement", () => {
     const section = buildPlanWorkflowSection(new Set())
     expect(section).toContain("Plans are executed by Tapestry")
@@ -148,7 +152,7 @@ describe("buildPlanWorkflowSection", () => {
   it("includes Pattern, Weft, Warp, and Tapestry by default", () => {
     const section = buildPlanWorkflowSection(new Set())
     expect(section).toContain("Pattern")
-    expect(section).toContain("Weft")
+    expect(section).toContain("Weft (primary reviewer)")
     expect(section).toContain("Warp")
     expect(section).toContain("Tapestry")
   })
@@ -170,6 +174,12 @@ describe("buildPlanWorkflowSection", () => {
     expect(section).not.toContain("REVIEW")
   })
 
+  it("includes review step for additional reviewers even when weft/warp are disabled", () => {
+    const section = buildPlanWorkflowSection(new Set(["weft", "warp"]), additionalReviewers)
+    expect(section).toContain("REVIEW")
+    expect(section).toContain("configured reviewers: Custom Reviewer (subagent_type \"review-custom\")")
+  })
+
   it("includes Warp in review step for security-relevant plans", () => {
     const section = buildPlanWorkflowSection(new Set())
     expect(section).toContain("Warp for security-relevant plans")
@@ -179,18 +189,55 @@ describe("buildPlanWorkflowSection", () => {
     const section = buildPlanWorkflowSection(new Set(["warp"]))
     expect(section).not.toContain("Warp")
   })
+
+  it("adds collection, comparison, and synthesis buckets", () => {
+    const section = buildPlanWorkflowSection(new Set())
+    expect(section).toContain("Collection phase")
+    expect(section).toContain("Comparison phase")
+    expect(section).toContain("Synthesis phase")
+    expect(section).toContain("consensus")
+    expect(section).toContain("discrepancies")
+    expect(section).toContain("unique findings")
+  })
 })
 
 describe("buildReviewWorkflowSection", () => {
+  const additionalReviewers = [
+    { key: "review-custom", label: "Custom Reviewer", source: "custom" as const, isValid: true },
+  ]
+
   it("returns empty string when both weft and warp disabled", () => {
     const section = buildReviewWorkflowSection(new Set(["weft", "warp"]))
     expect(section).toBe("")
+  })
+
+  it("includes ad-hoc review for additional reviewers when weft/warp are disabled", () => {
+    const section = buildReviewWorkflowSection(new Set(["weft", "warp"]), additionalReviewers)
+    expect(section).toContain("Ad-hoc review")
+    expect(section).toContain("configured additional reviewers: Custom Reviewer (subagent_type \"review-custom\")")
+    expect(section).not.toContain("Delegate to Weft")
   })
 
   it("includes ad-hoc review section by default", () => {
     const section = buildReviewWorkflowSection(new Set())
     expect(section).toContain("Ad-hoc review")
     expect(section).toContain("Weft")
+  })
+
+  it("requires collection, comparison, and synthesis buckets", () => {
+    const section = buildReviewWorkflowSection(new Set())
+    expect(section).toContain("Collection phase")
+    expect(section).toContain("Comparison phase")
+    expect(section).toContain("Synthesis phase")
+    expect(section).toContain("consensus")
+    expect(section).toContain("discrepancies")
+    expect(section).toContain("unique findings")
+  })
+
+  it("instructs to surface minority findings and escalate disagreements", () => {
+    const section = buildReviewWorkflowSection(new Set())
+    expect(section).toContain("Do not hide rejections or minority findings")
+    expect(section).toContain("Escalate real reviewer disagreements to the user")
   })
 
   it("includes Warp mandatory line when warp enabled", () => {
@@ -535,5 +582,25 @@ describe("composeLoomPrompt with categories", () => {
     const defaultPrompt = composeLoomPrompt()
     const withNoPatterned = composeLoomPrompt({ categories: { frontend: {} } })
     expect(withNoPatterned).not.toBe(defaultPrompt)
+  })
+})
+
+describe("composeLoomPrompt with additional reviewers", () => {
+  const additionalReviewers = [
+    { key: "review-custom", label: "Custom Reviewer", source: "custom" as const, isValid: true },
+    { key: "audit-bot", label: "Audit Bot", source: "custom" as const, isValid: true },
+  ]
+
+  it("keeps Weft as primary and names additional reviewers", () => {
+    const prompt = composeLoomPrompt({ additionalReviewers })
+    expect(prompt).toContain("Weft (primary reviewer)")
+    expect(prompt).toContain("Custom Reviewer (subagent_type \"review-custom\")")
+    expect(prompt).toContain("Audit Bot (subagent_type \"audit-bot\")")
+  })
+
+  it("maintains legacy prompt when additional reviewers are empty", () => {
+    const legacy = composeLoomPrompt()
+    const withEmpty = composeLoomPrompt({ additionalReviewers: [] })
+    expect(withEmpty).toBe(legacy)
   })
 })

--- a/src/agents/loom/prompt-composer.ts
+++ b/src/agents/loom/prompt-composer.ts
@@ -30,7 +30,7 @@ function formatAdditionalReviewers(additionalReviewers: ResolvedReviewer[]): str
   if (additionalReviewers.length === 0) return ""
 
   return additionalReviewers
-    .map((reviewer) => `${reviewer.label} (subagent_type \"${reviewer.key}\")`)
+    .map((reviewer) => `${reviewer.label} (subagent_type "${reviewer.key}")`)
     .join(", ")
 }
 

--- a/src/agents/loom/prompt-composer.ts
+++ b/src/agents/loom/prompt-composer.ts
@@ -11,6 +11,7 @@ import { buildProjectContextSection, buildDelegationTable } from "../dynamic-pro
 import type { AvailableAgent } from "../dynamic-prompt-builder"
 import { isAgentEnabled } from "../prompt-utils"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ResolvedReviewer } from "../../review/reviewer-resolution"
 
 export interface LoomPromptOptions {
   /** Set of disabled agent names (lowercase config keys) */
@@ -21,6 +22,16 @@ export interface LoomPromptOptions {
   customAgents?: AvailableAgent[]
   /** Categories config for category-aware shuttle routing */
   categories?: CategoriesConfig
+  /** Additional configured reviewers (Weft remains primary) */
+  additionalReviewers?: ResolvedReviewer[]
+}
+
+function formatAdditionalReviewers(additionalReviewers: ResolvedReviewer[]): string {
+  if (additionalReviewers.length === 0) return ""
+
+  return additionalReviewers
+    .map((reviewer) => `${reviewer.label} (subagent_type \"${reviewer.key}\")`)
+    .join(", ")
 }
 
 export function buildRoleSection(): string {
@@ -121,9 +132,13 @@ When delegating:
 </DelegationNarration>`
 }
 
-export function buildPlanWorkflowSection(disabled: Set<string>): string {
+export function buildPlanWorkflowSection(
+  disabled: Set<string>,
+  additionalReviewers: ResolvedReviewer[] = [],
+): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
+  const hasAdditionalReviewers = additionalReviewers.length > 0
   const hasTapestry = isAgentEnabled("tapestry", disabled)
   const hasPattern = isAgentEnabled("pattern", disabled)
 
@@ -133,12 +148,30 @@ export function buildPlanWorkflowSection(disabled: Set<string>): string {
     steps.push(`1. PLAN: Delegate to Pattern → produces a plan at \`.weave/plans/{name}.md\``)
   }
 
-  if (hasWeft || hasWarp) {
+  if (hasWeft || hasWarp || hasAdditionalReviewers) {
     const stepNum = hasPattern ? 2 : 1
-    const reviewers: string[] = []
-    if (hasWeft) reviewers.push("Weft")
-    if (hasWarp) reviewers.push("Warp for security-relevant plans")
-    steps.push(`${stepNum}. REVIEW: Delegate to ${reviewers.join(", ")} to validate the plan`)
+    const additionalList = formatAdditionalReviewers(additionalReviewers)
+    const reviewerLine = hasWeft
+      ? additionalList.length > 0
+        ? `Delegate to Weft (primary reviewer) and also to: ${additionalList}`
+        : "Delegate to Weft (primary reviewer)"
+      : additionalList.length > 0
+        ? `Delegate to configured reviewers: ${additionalList}`
+        : "Run review checks"
+    const reviewDetails: string[] = [
+      `${stepNum}. REVIEW: ${reviewerLine} to validate the plan`,
+      "   - Collection phase: gather each reviewer result independently",
+      "   - Comparison phase: compare reviewer outcomes structurally",
+      "   - Synthesis phase: report all findings in mandatory buckets: consensus, discrepancies, unique findings",
+      "   - Do not hide rejections or minority findings",
+      "   - Escalate real reviewer disagreements to the user before execution",
+    ]
+
+    if (hasWarp) {
+      reviewDetails.push("   - Warp for security-relevant plans")
+    }
+
+    steps.push(reviewDetails.join("\n"))
   }
 
   if (hasTapestry) {
@@ -159,17 +192,30 @@ Skip it for quick fixes, single-file changes, and simple questions.
 </PlanWorkflow>`
 }
 
-export function buildReviewWorkflowSection(disabled: Set<string>): string {
+export function buildReviewWorkflowSection(
+  disabled: Set<string>,
+  additionalReviewers: ResolvedReviewer[] = [],
+): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
+  const hasAdditionalReviewers = additionalReviewers.length > 0
 
-  if (!hasWeft && !hasWarp) return ""
+  if (!hasWeft && !hasWarp && !hasAdditionalReviewers) return ""
 
   const lines: string[] = []
 
   if (hasWeft) {
     lines.push("- Delegate to Weft after non-trivial changes (3+ files, or when quality matters)")
   }
+  const additionalList = formatAdditionalReviewers(additionalReviewers)
+  if (additionalList.length > 0) {
+    lines.push(`- Also delegate to configured additional reviewers: ${additionalList}`)
+  }
+  lines.push("- Collection phase: gather each reviewer result independently")
+  lines.push("- Comparison phase: compare reviewer outcomes structurally")
+  lines.push("- Synthesis phase: present mandatory buckets: consensus, discrepancies, unique findings")
+  lines.push("- Do not hide rejections or minority findings")
+  lines.push("- Escalate real reviewer disagreements to the user")
   if (hasWarp) {
     lines.push("- Warp is mandatory when changes touch auth, crypto, tokens, secrets, or input validation")
   }
@@ -273,6 +319,7 @@ export function composeLoomPrompt(options: LoomPromptOptions = {}): string {
   const fingerprint = options.fingerprint
   const customAgents = options.customAgents ?? []
   const categories = options.categories
+  const additionalReviewers = options.additionalReviewers ?? []
 
   const sections = [
     buildRoleSection(),
@@ -283,8 +330,8 @@ export function composeLoomPrompt(options: LoomPromptOptions = {}): string {
     buildDelegationNarrationSection(disabled),
     buildCategoryRoutingSection(categories, disabled),
     buildCustomAgentDelegationSection(customAgents, disabled),
-    buildPlanWorkflowSection(disabled),
-    buildReviewWorkflowSection(disabled),
+    buildPlanWorkflowSection(disabled, additionalReviewers),
+    buildReviewWorkflowSection(disabled, additionalReviewers),
     buildStyleSection(),
   ].filter((s) => s.length > 0)
 

--- a/src/agents/tapestry/index.test.ts
+++ b/src/agents/tapestry/index.test.ts
@@ -140,6 +140,37 @@ describe("createTapestryAgent", () => {
     expect(config.prompt).not.toContain("<CategoryRouting>")
   })
 
+  it("createTapestryAgentWithOptions preserves legacy prompt when additional reviewers are omitted or empty", () => {
+    const legacy = createTapestryAgent("claude-sonnet-4")
+    const withoutReviewers = createTapestryAgentWithOptions("claude-sonnet-4")
+    const withEmptyReviewers = createTapestryAgentWithOptions("claude-sonnet-4", undefined, undefined, undefined, [])
+
+    expect(withoutReviewers.prompt).toBe(legacy.prompt)
+    expect(withEmptyReviewers.prompt).toBe(legacy.prompt)
+  })
+
+  it("createTapestryAgentWithOptions includes additional reviewers when provided", () => {
+    const config = createTapestryAgentWithOptions(
+      "claude-sonnet-4",
+      new Set(),
+      undefined,
+      undefined,
+      [{ key: "review-custom", label: "Custom Reviewer", source: "custom", isValid: true }],
+    )
+
+    const reviewSection = getSection(config.prompt as string, "PostExecutionReview")
+    expect(reviewSection).not.toBeNull()
+    expect(reviewSection).toContain("Delegate to Weft")
+    expect(reviewSection).toContain("subagent_type \"review-custom\"")
+    expect(reviewSection).toContain("review.additional_agents")
+    expect(reviewSection).toContain("Consensus")
+    expect(reviewSection).toContain("Discrepancies")
+    expect(reviewSection).toContain("Unique findings")
+    expect(reviewSection).toContain("Do NOT average results")
+    expect(reviewSection).toContain("parallel Task calls")
+    expect(reviewSection).toContain("final sequential synthesis")
+  })
+
   it("createTapestryAgentWithOptions includes manual-only CategoryRouting when categories have no patterns", () => {
     const config = createTapestryAgentWithOptions(
       "claude-sonnet-4",

--- a/src/agents/tapestry/index.ts
+++ b/src/agents/tapestry/index.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { ResolvedContinuationConfig } from "../../config/continuation"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ResolvedReviewer } from "../../review/reviewer-resolution"
 import type { AgentFactory } from "../types"
 import { TAPESTRY_DEFAULTS } from "./default"
 import { composeTapestryPrompt } from "./prompt-composer"
@@ -16,18 +17,27 @@ export function createTapestryAgentWithOptions(
   disabledAgents?: Set<string>,
   continuation?: ResolvedContinuationConfig,
   categories?: CategoriesConfig,
+  additionalReviewers: ResolvedReviewer[] = [],
 ): AgentConfig {
   const hasDisabled = disabledAgents && disabledAgents.size > 0
-  const needsCustomPrompt = hasDisabled || continuation || categories
+  const hasAdditionalReviewers = additionalReviewers.length > 0
+  const needsCustomPrompt = hasDisabled || continuation || categories || hasAdditionalReviewers
 
   if (!needsCustomPrompt) {
     return { ...TAPESTRY_DEFAULTS, tools: { ...TAPESTRY_DEFAULTS.tools }, model, mode: "primary" }
   }
 
+  const prompt = composeTapestryPrompt({
+    disabledAgents,
+    continuation,
+    categories,
+    additionalReviewers,
+  })
+
   return {
     ...TAPESTRY_DEFAULTS,
     tools: { ...TAPESTRY_DEFAULTS.tools },
-    prompt: composeTapestryPrompt({ disabledAgents, continuation, categories }),
+    prompt,
     model,
     mode: "primary",
   }

--- a/src/agents/tapestry/prompt-composer.test.ts
+++ b/src/agents/tapestry/prompt-composer.test.ts
@@ -118,6 +118,43 @@ describe("buildTapestryPostExecutionReviewSection", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set())
     expect(section).toContain("user approval")
   })
+
+  it("requires collection/comparison plus structured synthesis for terminal reviewers", () => {
+    const section = buildTapestryPostExecutionReviewSection(new Set())
+    expect(section).toContain("Always collect every reviewer output before synthesis")
+    expect(section).toContain("Do NOT average results")
+    expect(section).toContain("Consensus")
+    expect(section).toContain("Discrepancies")
+    expect(section).toContain("Unique findings")
+  })
+
+  it("allows parallel task calls for independent reviewers but requires final sequential synthesis", () => {
+    const section = buildTapestryPostExecutionReviewSection(new Set())
+    expect(section).toContain("independent reviewers MAY run as parallel Task calls")
+    expect(section).toContain("final sequential synthesis")
+  })
+
+  it("includes additional reviewers in terminal review workflow when provided", () => {
+    const section = buildTapestryPostExecutionReviewSection(new Set(), [
+      { key: "review-custom", label: "Custom Reviewer", source: "custom", isValid: true },
+    ])
+
+    expect(section).toContain("Delegate to Weft")
+    expect(section).toContain("Delegate to Custom Reviewer")
+    expect(section).toContain('subagent_type "review-custom"')
+    expect(section).toContain("review.additional_agents")
+  })
+
+  it("still delegates terminal review when built-ins are disabled but additional reviewers are configured", () => {
+    const section = buildTapestryPostExecutionReviewSection(new Set(["weft", "warp"]), [
+      { key: "review-custom", label: "Custom Reviewer", source: "custom", isValid: true },
+    ])
+
+    expect(section).toContain("Task tool")
+    expect(section).toContain("Delegate to Custom Reviewer")
+    expect(section).not.toContain('subagent_type "weft"')
+    expect(section).not.toContain('subagent_type "warp"')
+  })
 })
 
 describe("individual tapestry section builders", () => {

--- a/src/agents/tapestry/prompt-composer.ts
+++ b/src/agents/tapestry/prompt-composer.ts
@@ -9,6 +9,7 @@
 import { isAgentEnabled } from "../prompt-utils"
 import type { ResolvedContinuationConfig } from "../../config/continuation"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ResolvedReviewer } from "../../review/reviewer-resolution"
 
 export interface TapestryPromptOptions {
   /** Set of disabled agent names (lowercase config keys) */
@@ -17,6 +18,8 @@ export interface TapestryPromptOptions {
   continuation?: ResolvedContinuationConfig
   /** Categories config for dynamic category routing section */
   categories?: CategoriesConfig
+  /** Additional configured terminal reviewers from review.additional_agents */
+  additionalReviewers?: ResolvedReviewer[]
 }
 
 export function buildTapestryRoleSection(): string {
@@ -333,11 +336,15 @@ After Shuttle completes a task — BEFORE marking \`- [ ]\` → \`- [x]\`:
 </Verification>`
 }
 
-export function buildTapestryPostExecutionReviewSection(disabled: Set<string>): string {
+export function buildTapestryPostExecutionReviewSection(
+  disabled: Set<string>,
+  additionalReviewers: ResolvedReviewer[] = [],
+): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
+  const hasAdditionalReviewers = additionalReviewers.length > 0
 
-  if (!hasWeft && !hasWarp) {
+  if (!hasWeft && !hasWarp && !hasAdditionalReviewers) {
     return `<PostExecutionReview>
 This section applies only after ALL plan tasks are already checked off.
 
@@ -354,7 +361,15 @@ After ALL plan tasks are checked off:
 
   const reviewerLines: string[] = []
   if (hasWeft) {
-    reviewerLines.push(`   - Delegate to Weft: subagent_type "weft" — reviews code quality`)
+    reviewerLines.push(`   - Delegate to Weft: subagent_type "weft" — primary terminal quality reviewer`)
+  }
+  if (hasAdditionalReviewers) {
+    reviewerLines.push(
+      ...additionalReviewers.map(
+        (reviewer) =>
+          `   - Delegate to ${reviewer.label}: subagent_type "${reviewer.key}" — additional ${reviewer.source} reviewer from review.additional_agents`,
+      ),
+    )
   }
   if (hasWarp) {
     reviewerLines.push(
@@ -362,7 +377,11 @@ After ALL plan tasks are checked off:
     )
   }
 
-  const reviewerNames = [hasWeft && "Weft", hasWarp && "Warp"].filter(Boolean).join(" and ")
+  const reviewerNames = [
+    hasWeft && "Weft",
+    ...additionalReviewers.map((reviewer) => reviewer.label),
+    hasWarp && "Warp",
+  ].filter(Boolean).join(", ")
 
   return `<PostExecutionReview>
 This section applies only when no unchecked plan tasks remain.
@@ -372,15 +391,25 @@ Ignore this section completely while any unchecked task remains.
 When all plan tasks are checked off:
 
 1. Identify all changed files:
-    - If a **Start SHA** was provided in the session context, run \`git diff --name-only <start-sha>..HEAD\` to get the complete list of changed files (this captures all changes including intermediate commits)
-   - If no Start SHA is available (non-git workspace), use the plan's \`**Files**:\` fields as the review scope
-2. Run the required terminal validation workflow using the Task tool:
+     - If a **Start SHA** was provided in the session context, run \`git diff --name-only <start-sha>..HEAD\` to get the complete list of changed files (this captures all changes including intermediate commits)
+    - If no Start SHA is available (non-git workspace), use the plan's \`**Files**:\` fields as the review scope
+ 2. Run the required terminal review workflow using the Task tool:
 ${reviewerLines.join("\n")}
-   - Include the list of changed files in your prompt to each terminal validator
-3. Report the terminal results to the user:
-   - Summarize ${reviewerNames}'s findings (APPROVE or REJECT with details)
-   - If either validator REJECTS, present the blocking issues to the user for decision — do NOT attempt to fix them yourself
-   - Tapestry follows the plan; terminal findings require user approval before any further changes
+    - Include the list of changed files in every reviewer prompt
+    - Default-safe parallelism: independent reviewers MAY run as parallel Task calls in one response; if dependencies are unclear, run sequentially
+    - Always collect every reviewer output before synthesis (APPROVE, REJECT, BLOCKED, or tool failure)
+ 3. Compare reviewer outputs explicitly before answering the user:
+    - Do NOT average results
+    - Do NOT discard minority or isolated findings
+    - If any reviewer is BLOCKED or fails to return a result, report that reviewer as blocked/failing with the reason/output
+ 4. Provide one final sequential synthesis to the user (after all reviewer outputs are collected):
+    - **Consensus**: findings/verdicts shared by multiple reviewers
+    - **Discrepancies**: direct reviewer disagreements that need user decision
+    - **Unique findings**: material concerns raised by only one reviewer
+    - Include each reviewer's final verdict (APPROVE/REJECT/BLOCKED)
+    - If any reviewer REJECTS or BLOCKS, present all blocking issues for user decision — do NOT attempt to fix them yourself
+    - Tapestry follows the plan; terminal findings require user approval before any further changes
+    - Reviewers involved: ${reviewerNames}
 </PostExecutionReview>`
 }
 
@@ -419,6 +448,7 @@ export function composeTapestryPrompt(options: TapestryPromptOptions = {}): stri
       .filter(([, cfg]) => cfg.patterns && cfg.patterns.length > 0)
       .map(([name]) => name)
     : undefined
+  const additionalReviewers = options.additionalReviewers ?? []
 
   const sections = [
     buildTapestryRoleSection(),
@@ -432,7 +462,7 @@ export function composeTapestryPrompt(options: TapestryPromptOptions = {}): stri
     continuationHint,
     buildTapestryVerificationSection(),
     buildTapestryErrorHandlingSection(),
-    buildTapestryPostExecutionReviewSection(disabled),
+    buildTapestryPostExecutionReviewSection(disabled, additionalReviewers),
     buildTapestryExecutionSection(),
     buildTapestryStyleSection(),
   ].filter((section): section is string => Boolean(section))

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test"
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { loadWeaveConfig } from "./loader"
+import { getLastConfigLoadResult, loadWeaveConfig } from "./loader"
 import { resolveContinuationConfig } from "./continuation"
 
 function createTmpDir(): string {
@@ -142,6 +142,44 @@ describe("loadWeaveConfig", () => {
     // Should not throw — should log and return defaults
     const config = loadWeaveConfig(testDir)
     expect(config).toBeDefined()
+  })
+
+  it("allows project review.additional_agents [] to clear inherited user reviewers", () => {
+    const userConfigDir = join(testDir, ".config", "opencode")
+    mkdirSync(userConfigDir, { recursive: true })
+    writeFileSync(
+      join(userConfigDir, "weave-opencode.json"),
+      JSON.stringify({ review: { additional_agents: ["user-reviewer"] } }),
+    )
+
+    const opencodeDir = join(testDir, ".opencode")
+    mkdirSync(opencodeDir, { recursive: true })
+    writeFileSync(
+      join(opencodeDir, "weave-opencode.json"),
+      JSON.stringify({ review: { additional_agents: [] } }),
+    )
+
+    const config = loadWeaveConfig(testDir, undefined, testDir)
+    expect(config.review?.additional_agents).toEqual([])
+  })
+
+  it("drops invalid review section but preserves valid agent overrides", () => {
+    const opencodeDir = join(testDir, ".opencode")
+    mkdirSync(opencodeDir, { recursive: true })
+    writeFileSync(
+      join(opencodeDir, "weave-opencode.json"),
+      JSON.stringify({
+        agents: { loom: { model: "preserved-model" } },
+        review: { additional_agents: ["security-reviewer", 42] },
+      }),
+    )
+
+    const config = loadWeaveConfig(testDir)
+    expect(config.agents?.loom?.model).toBe("preserved-model")
+    expect(config.review).toBeUndefined()
+
+    const last = getLastConfigLoadResult()
+    expect(last?.diagnostics.some((diag) => diag.section === "review")).toBe(true)
   })
 
   // Regression tests for issue #30:

--- a/src/config/merge.test.ts
+++ b/src/config/merge.test.ts
@@ -120,4 +120,36 @@ describe("mergeConfigs", () => {
     const result = mergeConfigs({}, {})
     expect(result.custom_agents).toBeUndefined()
   })
+
+  it("uses user review.additional_agents when project review is absent", () => {
+    const result = mergeConfigs(
+      { review: { additional_agents: ["user-reviewer"] } },
+      {},
+    )
+    expect(result.review?.additional_agents).toEqual(["user-reviewer"])
+  })
+
+  it("project review.additional_agents overrides user values (no union)", () => {
+    const result = mergeConfigs(
+      { review: { additional_agents: ["user-reviewer"] } },
+      { review: { additional_agents: ["project-reviewer"] } },
+    )
+    expect(result.review?.additional_agents).toEqual(["project-reviewer"])
+  })
+
+  it("keeps inherited user reviewers when project.review exists without additional_agents", () => {
+    const result = mergeConfigs(
+      { review: { additional_agents: ["user-reviewer"] } },
+      { review: {} },
+    )
+    expect(result.review?.additional_agents).toEqual(["user-reviewer"])
+  })
+
+  it("allows project review.additional_agents [] to clear inherited user reviewers", () => {
+    const result = mergeConfigs(
+      { review: { additional_agents: ["user-reviewer"] } },
+      { review: { additional_agents: [] } },
+    )
+    expect(result.review?.additional_agents).toEqual([])
+  })
 })

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -40,6 +40,22 @@ export function mergeConfigs(
   user: DeepPartial<WeaveConfig>,
   project: DeepPartial<WeaveConfig>,
 ): DeepPartial<WeaveConfig> {
+  const mergedReview =
+    user.review || project.review
+      ? (deepMergeObjects(
+          (user.review ?? {}) as Record<string, unknown>,
+          (project.review ?? {}) as Record<string, unknown>,
+        ) as DeepPartial<WeaveConfig>["review"])
+      : undefined
+
+  // Special-case merge semantics: review.additional_agents is project-overrides-user
+  // (not a union), so projects can intentionally clear inherited user reviewers
+  // via [] without carrying over user-level entries.
+  const mergedReviewAdditionalAgents =
+    project.review?.additional_agents !== undefined
+      ? project.review.additional_agents
+      : user.review?.additional_agents
+
   return {
     ...user,
     ...project,
@@ -69,6 +85,14 @@ export function mergeConfigs(
     disabled_agents: mergeStringArrays(user.disabled_agents, project.disabled_agents),
     disabled_skills: mergeStringArrays(user.disabled_skills, project.disabled_skills),
     background: project.background ?? user.background,
+    review: mergedReview
+      ? {
+          ...mergedReview,
+          ...(mergedReviewAdditionalAgents !== undefined
+            ? { additional_agents: mergedReviewAdditionalAgents }
+            : {}),
+        }
+      : undefined,
     tmux: project.tmux ?? user.tmux,
     experimental:
       user.experimental || project.experimental

--- a/src/config/schema-json-schema.test.ts
+++ b/src/config/schema-json-schema.test.ts
@@ -68,6 +68,7 @@ describe("generateWeaveConfigJsonSchema", () => {
       "skill_directories",
       "background",
       "analytics",
+      "review",
       "continuation",
       "tmux",
       "experimental",
@@ -102,6 +103,7 @@ describe("generateWeaveConfigJsonSchema", () => {
     const { root } = getRootSchema()
     const agents = getProperty(root, "agents")
     const customAgents = getProperty(root, "custom_agents")
+    const review = getProperty(root, "review")
     const continuation = getProperty(root, "continuation")
     const tmux = getProperty(root, "tmux")
     const agentOverride = agents?.additionalProperties as JsonSchemaObject
@@ -114,6 +116,13 @@ describe("generateWeaveConfigJsonSchema", () => {
 
     expect(customAgents?.type).toBe("object")
     expect((customAgents?.additionalProperties as JsonSchemaObject)?.type).toBe("object")
+
+    expect(review?.type).toBe("object")
+    expect(getProperty(review as JsonSchemaObject, "additional_agents")?.type).toBe("array")
+    expect(
+      ((getProperty(review as JsonSchemaObject, "additional_agents") as JsonSchemaObject)
+        ?.items as JsonSchemaObject)?.type,
+    ).toBe("string")
 
     expect(getProperty(continuation as JsonSchemaObject, "idle")?.type).toBe("object")
     expect(getProperty(tmux as JsonSchemaObject, "layout")?.enum).toEqual([

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -288,6 +288,69 @@ describe("WeaveConfigSchema", () => {
     }
   })
 
+  it("parses review.additional_agents as string array", () => {
+    const result = WeaveConfigSchema.safeParse({
+      review: { additional_agents: ["security-reviewer", "perf-reviewer"] },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.review?.additional_agents).toEqual([
+        "security-reviewer",
+        "perf-reviewer",
+      ])
+    }
+  })
+
+  it("parses empty review.additional_agents array", () => {
+    const result = WeaveConfigSchema.safeParse({
+      review: { additional_agents: [] },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.review?.additional_agents).toEqual([])
+    }
+  })
+
+  it("rejects non-string values in review.additional_agents", () => {
+    const result = WeaveConfigSchema.safeParse({
+      review: { additional_agents: ["security-reviewer", 42] },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts duplicate and builtin names in review.additional_agents (runtime validation handles them)", () => {
+    const result = WeaveConfigSchema.safeParse({
+      review: {
+        additional_agents: ["security-reviewer", "security-reviewer", "weft", "warp", "loom"],
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.review?.additional_agents).toEqual([
+        "security-reviewer",
+        "security-reviewer",
+        "weft",
+        "warp",
+        "loom",
+      ])
+    }
+  })
+
+  it("accepts custom agent display_name used for reviewer labels", () => {
+    const result = WeaveConfigSchema.safeParse({
+      custom_agents: {
+        "sec-reviewer": {
+          prompt: "Review security changes.",
+          display_name: "Security Reviewer",
+        },
+      },
+      review: {
+        additional_agents: ["sec-reviewer"],
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
   it("parses continuation config with recovery and idle overrides", () => {
     const result = WeaveConfigSchema.safeParse({
       continuation: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -134,6 +134,15 @@ export const AnalyticsConfigSchema = z.object({
   use_fingerprint: z.boolean().optional(),
 })
 
+export const ReviewConfigSchema = z.object({
+  /**
+   * Additional reviewer agents (by custom_agents key) to run alongside the default reviewer.
+   *
+   * Example: ["security-reviewer", "performance-reviewer"]
+   */
+  additional_agents: z.array(z.string()).optional(),
+})
+
 export const ContinuationRecoveryConfigSchema = z.object({
   /** Whether Weave should inject a resume prompt after session compaction/context restoration. */
   compaction: z.boolean().optional(),
@@ -174,6 +183,7 @@ export const WeaveConfigSchema = z.object({
   skill_directories: z.array(SafeRelativePathSchema).optional(),
   background: BackgroundConfigSchema.optional(),
   analytics: AnalyticsConfigSchema.optional(),
+  review: ReviewConfigSchema.optional(),
   continuation: ContinuationConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),
   experimental: ExperimentalConfigSchema.optional(),
@@ -190,6 +200,7 @@ export type CategoryConfig = z.infer<typeof CategoryConfigSchema>
 export type CategoriesConfig = z.infer<typeof CategoriesConfigSchema>
 export type BackgroundConfig = z.infer<typeof BackgroundConfigSchema>
 export type AnalyticsConfig = z.infer<typeof AnalyticsConfigSchema>
+export type ReviewConfig = z.infer<typeof ReviewConfigSchema>
 export type ContinuationRecoveryConfig = z.infer<typeof ContinuationRecoveryConfigSchema>
 export type ContinuationIdleConfig = z.infer<typeof ContinuationIdleConfigSchema>
 export type ContinuationConfig = z.infer<typeof ContinuationConfigSchema>

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -13,6 +13,7 @@ import { buildCustomAgent, buildCustomAgentMetadata } from "./agents/custom-agen
 import { updateBuiltinDisplayName } from "./shared/agent-display-names"
 import { addBuiltinNameVariant } from "./agents/agent-builder"
 import { debug } from "./shared/log"
+import { resolveEffectiveReviewers } from "./review/reviewer-resolution"
 
 export interface WeaveManagers {
   configHandler: ConfigHandler
@@ -47,6 +48,11 @@ export function createManagers(options: {
   }
 
   // Step 2: Build builtins WITH custom agent metadata for Loom's prompt
+  const reviewerResolution = resolveEffectiveReviewers({
+    pluginConfig,
+    customAgentMetadata,
+  })
+
   const agents = createBuiltinAgents({
     disabledAgents: pluginConfig.disabled_agents,
     agentOverrides: pluginConfig.agents,
@@ -54,6 +60,7 @@ export function createManagers(options: {
     resolveSkills,
     fingerprint,
     customAgentMetadata,
+    additionalReviewers: reviewerResolution.effectiveReviewers,
     continuation,
   })
 

--- a/src/features/builtin-commands/templates/start-work.ts
+++ b/src/features/builtin-commands/templates/start-work.ts
@@ -40,6 +40,7 @@ For each unchecked \`- [ ]\` task in the plan:
 - A progress update is **not** a stopping point
 - Do **not** ask the user what to do next while unchecked tasks remain
 - Do **not** mention terminal validation, review, reviewers, final summary, completion, or post-execution steps while unchecked tasks remain
+- Terminal post-execution review routing (Weft/Warp + any configured additional reviewers) starts only after all plan checkboxes are checked
 - If asked what to do now while unchecked tasks remain, answer with only the immediate next delegation action
 - Keep mid-plan responses to one sentence or one short bullet
 - If the current task is blocked, document the reason and move to the next unchecked task that is not blocked

--- a/src/features/evals/schema.test.ts
+++ b/src/features/evals/schema.test.ts
@@ -61,6 +61,31 @@ describe("eval schemas", () => {
     })
   })
 
+  it("validates builtin Tapestry target variants with additional reviewers", () => {
+    const result = EvalCaseSchema.safeParse({
+      id: "tapestry-additional-reviewers-contract",
+      title: "Tapestry additional reviewers variant",
+      phase: "prompt",
+      target: {
+        kind: "builtin-agent-prompt",
+        agent: "tapestry",
+        variant: {
+          additionalReviewers: [
+            {
+              key: "review-custom",
+              label: "Custom Reviewer",
+              source: "custom",
+            },
+          ],
+        },
+      },
+      executor: { kind: "prompt-render" },
+      evaluators: [{ kind: "contains-all", patterns: ["<Role>"] }],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
   it("rejects malformed builtin Tapestry target categories", () => {
     const result = EvalCaseSchema.safeParse({
       id: "tapestry-categories-invalid",

--- a/src/features/evals/schema.ts
+++ b/src/features/evals/schema.ts
@@ -26,6 +26,11 @@ export const EvalSuiteMetadataSchema = z.object({
 export const BuiltinAgentPromptVariantSchema = z.object({
   disabledAgents: z.array(NonEmptyString).optional(),
   categories: CategoriesConfigSchema.optional(),
+  additionalReviewers: z.array(z.object({
+    key: NonEmptyString,
+    label: NonEmptyString,
+    source: z.literal("custom"),
+  })).optional(),
 })
 
 export const BuiltinAgentPromptTargetSchema = z.object({

--- a/src/features/evals/targets/builtin-agent-target.test.ts
+++ b/src/features/evals/targets/builtin-agent-target.test.ts
@@ -95,4 +95,30 @@ describe("resolveBuiltinAgentTarget", () => {
     expect(delegationSection).not.toContain("shuttle-docs")
     expect(delegationSection).not.toContain("shuttle-{category}")
   })
+
+  it("passes additional reviewer variants into Tapestry prompt composition", () => {
+    const result = resolveBuiltinAgentTarget({
+      kind: "builtin-agent-prompt",
+      agent: "tapestry",
+      variant: {
+        additionalReviewers: [
+          {
+            key: "review-custom",
+            label: "Custom Reviewer",
+            source: "custom",
+          },
+        ],
+      },
+    })
+
+    const reviewSection = getSection(result.artifacts.renderedPrompt, "PostExecutionReview")
+    expect(reviewSection).not.toBeNull()
+    expect(reviewSection).toContain("Delegate to Weft")
+    expect(reviewSection).toContain("Delegate to Custom Reviewer")
+    expect(reviewSection).toContain('subagent_type "review-custom"')
+    expect(reviewSection).toContain("review.additional_agents")
+    expect(reviewSection).toContain("Consensus")
+    expect(reviewSection).toContain("Discrepancies")
+    expect(reviewSection).toContain("Unique findings")
+  })
 })

--- a/src/features/evals/targets/builtin-agent-target.ts
+++ b/src/features/evals/targets/builtin-agent-target.ts
@@ -16,10 +16,14 @@ function cloneTools(tools: Record<string, boolean> | undefined): Record<string, 
 
 export function resolveBuiltinAgentTarget(target: BuiltinAgentPromptTarget): ResolvedTarget {
   const disabledAgents = new Set(target.variant?.disabledAgents ?? [])
+  const additionalReviewers = (target.variant?.additionalReviewers ?? []).map((reviewer) => ({
+    ...reviewer,
+    isValid: true as const,
+  }))
 
   switch (target.agent) {
     case "loom": {
-      const renderedPrompt = composeLoomPrompt({ disabledAgents })
+      const renderedPrompt = composeLoomPrompt({ disabledAgents, additionalReviewers })
       return {
         target,
         artifacts: {
@@ -38,6 +42,7 @@ export function resolveBuiltinAgentTarget(target: BuiltinAgentPromptTarget): Res
       const renderedPrompt = composeTapestryPrompt({
         disabledAgents,
         categories: target.variant?.categories,
+        additionalReviewers,
       })
       return {
         target,

--- a/src/features/evals/types.ts
+++ b/src/features/evals/types.ts
@@ -38,6 +38,11 @@ export type BuiltinEvalAgentName = WeaveAgentName
 export interface BuiltinAgentPromptVariant {
   disabledAgents?: string[]
   categories?: CategoriesConfig
+  additionalReviewers?: Array<{
+    key: string
+    label: string
+    source: "custom"
+  }>
 }
 
 export interface BuiltinAgentPromptTarget {

--- a/src/review/reviewer-resolution.test.ts
+++ b/src/review/reviewer-resolution.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, spyOn } from "bun:test"
+import type { WeaveConfig } from "../config/schema"
+import { resolveEffectiveReviewers } from "./reviewer-resolution"
+
+describe("resolveEffectiveReviewers", () => {
+  it("rejects additional reviewers configured as mode primary", () => {
+    const warnSpy = spyOn(console, "error").mockImplementation(() => {})
+
+    const config: WeaveConfig = {
+      custom_agents: {
+        "primary-reviewer": { mode: "primary", model: "gpt-4o" },
+      },
+      review: {
+        additional_agents: ["primary-reviewer"],
+      },
+    }
+
+    const metadata = [
+      {
+        name: "primary-reviewer",
+        description: "Primary Reviewer",
+        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+      },
+    ]
+
+    const result = resolveEffectiveReviewers({
+      pluginConfig: config,
+      customAgentMetadata: metadata,
+    })
+
+    expect(result.reviewers).toHaveLength(1)
+    expect(result.reviewers[0]?.isValid).toBe(false)
+    expect(result.effectiveReviewers).toHaveLength(0)
+    expect(result.warnings.some((w) => w.includes('mode "primary" cannot be delegated via subagent_type'))).toBe(
+      true,
+    )
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('mode "primary"'))).toBe(true)
+
+    warnSpy.mockRestore()
+  })
+
+  it("allows additional reviewers in mode subagent or all", () => {
+    const config: WeaveConfig = {
+      custom_agents: {
+        "subagent-reviewer": { mode: "subagent", model: "gpt-4o" },
+        "all-reviewer": { mode: "all", model: "gpt-4o" },
+      },
+      review: {
+        additional_agents: ["subagent-reviewer", "all-reviewer"],
+      },
+    }
+
+    const metadata = [
+      {
+        name: "subagent-reviewer",
+        description: "Subagent Reviewer",
+        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+      },
+      {
+        name: "all-reviewer",
+        description: "All Reviewer",
+        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+      },
+    ]
+
+    const result = resolveEffectiveReviewers({
+      pluginConfig: config,
+      customAgentMetadata: metadata,
+    })
+
+    expect(result.warnings).toHaveLength(0)
+    expect(result.reviewers).toHaveLength(2)
+    expect(result.reviewers.every((reviewer) => reviewer.isValid)).toBe(true)
+    expect(result.effectiveReviewers.map((r) => r.key)).toEqual(["subagent-reviewer", "all-reviewer"])
+  })
+})

--- a/src/review/reviewer-resolution.test.ts
+++ b/src/review/reviewer-resolution.test.ts
@@ -6,37 +6,39 @@ describe("resolveEffectiveReviewers", () => {
   it("rejects additional reviewers configured as mode primary", () => {
     const warnSpy = spyOn(console, "error").mockImplementation(() => {})
 
-    const config: WeaveConfig = {
-      custom_agents: {
-        "primary-reviewer": { mode: "primary", model: "gpt-4o" },
-      },
-      review: {
-        additional_agents: ["primary-reviewer"],
-      },
+    try {
+      const config: WeaveConfig = {
+        custom_agents: {
+          "primary-reviewer": { mode: "primary", model: "gpt-4o" },
+        },
+        review: {
+          additional_agents: ["primary-reviewer"],
+        },
+      }
+
+      const metadata = [
+        {
+          name: "primary-reviewer",
+          description: "Primary Reviewer",
+          metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+        },
+      ]
+
+      const result = resolveEffectiveReviewers({
+        pluginConfig: config,
+        customAgentMetadata: metadata,
+      })
+
+      expect(result.reviewers).toHaveLength(1)
+      expect(result.reviewers[0]?.isValid).toBe(false)
+      expect(result.effectiveReviewers).toHaveLength(0)
+      expect(result.warnings.some((w) => w.includes('mode "primary" cannot be delegated via subagent_type'))).toBe(
+        true,
+      )
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('mode "primary"'))).toBe(true)
+    } finally {
+      warnSpy.mockRestore()
     }
-
-    const metadata = [
-      {
-        name: "primary-reviewer",
-        description: "Primary Reviewer",
-        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
-      },
-    ]
-
-    const result = resolveEffectiveReviewers({
-      pluginConfig: config,
-      customAgentMetadata: metadata,
-    })
-
-    expect(result.reviewers).toHaveLength(1)
-    expect(result.reviewers[0]?.isValid).toBe(false)
-    expect(result.effectiveReviewers).toHaveLength(0)
-    expect(result.warnings.some((w) => w.includes('mode "primary" cannot be delegated via subagent_type'))).toBe(
-      true,
-    )
-    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('mode "primary"'))).toBe(true)
-
-    warnSpy.mockRestore()
   })
 
   it("allows additional reviewers in mode subagent or all", () => {
@@ -72,5 +74,42 @@ describe("resolveEffectiveReviewers", () => {
     expect(result.reviewers).toHaveLength(2)
     expect(result.reviewers.every((reviewer) => reviewer.isValid)).toBe(true)
     expect(result.effectiveReviewers.map((r) => r.key)).toEqual(["subagent-reviewer", "all-reviewer"])
+  })
+
+  it("matches disabled_agents case-insensitively for additional reviewers", () => {
+    const warnSpy = spyOn(console, "error").mockImplementation(() => {})
+
+    try {
+      const config: WeaveConfig = {
+        custom_agents: {
+          "Review-Custom": { mode: "subagent", model: "gpt-4o" },
+        },
+        disabled_agents: ["review-custom"],
+        review: {
+          additional_agents: ["Review-Custom"],
+        },
+      }
+
+      const metadata = [
+        {
+          name: "Review-Custom",
+          description: "Custom Reviewer",
+          metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+        },
+      ]
+
+      const result = resolveEffectiveReviewers({
+        pluginConfig: config,
+        customAgentMetadata: metadata,
+      })
+
+      expect(result.reviewers).toHaveLength(1)
+      expect(result.reviewers[0]?.isValid).toBe(false)
+      expect(result.effectiveReviewers).toHaveLength(0)
+      expect(result.warnings.some((w) => w.includes("agent is disabled via disabled_agents"))).toBe(true)
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("agent is disabled via disabled_agents"))).toBe(true)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 })

--- a/src/review/reviewer-resolution.ts
+++ b/src/review/reviewer-resolution.ts
@@ -27,7 +27,7 @@ export function resolveEffectiveReviewers(input: {
   const { pluginConfig, customAgentMetadata } = input
 
   const requested = pluginConfig.review?.additional_agents ?? []
-  const disabled = new Set(pluginConfig.disabled_agents ?? [])
+  const disabled = new Set((pluginConfig.disabled_agents ?? []).map((agent) => agent.toLowerCase()))
   const customConfig = pluginConfig.custom_agents ?? {}
 
   const metadataByLower = new Map<string, AvailableAgent>()
@@ -89,7 +89,7 @@ export function resolveEffectiveReviewers(input: {
       continue
     }
 
-    if (disabled.has(resolvedCustomKey)) {
+    if (disabled.has(resolvedCustomKey.toLowerCase())) {
       const warning = `Ignoring reviewer \"${resolvedCustomKey}\" in review.additional_agents: agent is disabled via disabled_agents`
       warnings.push(warning)
       warnConfig(warning)

--- a/src/review/reviewer-resolution.ts
+++ b/src/review/reviewer-resolution.ts
@@ -1,0 +1,137 @@
+import type { WeaveConfig } from "../config/schema"
+import type { AvailableAgent } from "../agents/dynamic-prompt-builder"
+import { warnConfig } from "../shared/log"
+
+export type ReviewerSource = "builtin" | "custom"
+
+export interface ResolvedReviewer {
+  key: string
+  label: string
+  source: ReviewerSource
+  isValid: boolean
+}
+
+export interface ReviewerResolutionResult {
+  reviewers: ResolvedReviewer[]
+  effectiveReviewers: ResolvedReviewer[]
+  warnings: string[]
+}
+
+const RESERVED_REVIEWER_KEYS = new Set(["weft", "warp"])
+const BUILTIN_AGENT_KEYS = new Set(["loom", "tapestry", "shuttle", "pattern", "thread", "spindle", "weft", "warp"])
+
+export function resolveEffectiveReviewers(input: {
+  pluginConfig: WeaveConfig
+  customAgentMetadata: AvailableAgent[]
+}): ReviewerResolutionResult {
+  const { pluginConfig, customAgentMetadata } = input
+
+  const requested = pluginConfig.review?.additional_agents ?? []
+  const disabled = new Set(pluginConfig.disabled_agents ?? [])
+  const customConfig = pluginConfig.custom_agents ?? {}
+
+  const metadataByLower = new Map<string, AvailableAgent>()
+  for (const agent of customAgentMetadata) {
+    metadataByLower.set(agent.name.toLowerCase(), agent)
+  }
+
+  const customByLower = new Map<string, string>()
+  for (const key of Object.keys(customConfig)) {
+    customByLower.set(key.toLowerCase(), key)
+  }
+
+  const reviewers: ResolvedReviewer[] = []
+  const warnings: string[] = []
+  const seen = new Set<string>()
+
+  for (const raw of requested) {
+    const key = raw.trim()
+    if (!key) {
+      const warning = "Ignoring empty review.additional_agents entry — remove empty values from config"
+      warnings.push(warning)
+      warnConfig(warning)
+      continue
+    }
+
+    const normalized = key.toLowerCase()
+    if (seen.has(normalized)) {
+      const warning = `Ignoring duplicate reviewer \"${key}\" in review.additional_agents`
+      warnings.push(warning)
+      warnConfig(warning)
+      continue
+    }
+    seen.add(normalized)
+
+    const source: ReviewerSource = BUILTIN_AGENT_KEYS.has(normalized) ? "builtin" : "custom"
+
+    if (RESERVED_REVIEWER_KEYS.has(normalized)) {
+      const warning = `Ignoring reviewer \"${key}\" in review.additional_agents: \"${normalized}\" is managed by built-in review flow`
+      warnings.push(warning)
+      warnConfig(warning)
+      reviewers.push({ key: normalized, label: normalized, source: "builtin", isValid: false })
+      continue
+    }
+
+    if (source === "builtin") {
+      const warning = `Ignoring reviewer \"${key}\" in review.additional_agents: only custom_agents keys are supported`
+      warnings.push(warning)
+      warnConfig(warning)
+      reviewers.push({ key: normalized, label: key, source, isValid: false })
+      continue
+    }
+
+    const resolvedCustomKey = customByLower.get(normalized)
+    if (!resolvedCustomKey) {
+      const warning = `Ignoring reviewer \"${key}\" in review.additional_agents: custom agent not found`
+      warnings.push(warning)
+      warnConfig(warning)
+      reviewers.push({ key, label: key, source, isValid: false })
+      continue
+    }
+
+    if (disabled.has(resolvedCustomKey)) {
+      const warning = `Ignoring reviewer \"${resolvedCustomKey}\" in review.additional_agents: agent is disabled via disabled_agents`
+      warnings.push(warning)
+      warnConfig(warning)
+      reviewers.push({ key: resolvedCustomKey, label: resolvedCustomKey, source, isValid: false })
+      continue
+    }
+
+    const metadata = metadataByLower.get(resolvedCustomKey.toLowerCase())
+    if (!metadata) {
+      const warning = `Ignoring reviewer \"${resolvedCustomKey}\" in review.additional_agents: custom agent metadata is unavailable`
+      warnings.push(warning)
+      warnConfig(warning)
+      reviewers.push({ key: resolvedCustomKey, label: resolvedCustomKey, source, isValid: false })
+      continue
+    }
+
+    const customDisplay = customConfig[resolvedCustomKey]?.display_name?.trim()
+    const mode = customConfig[resolvedCustomKey]?.mode
+    if (mode === "primary") {
+      const warning = `Ignoring reviewer \"${resolvedCustomKey}\" in review.additional_agents: custom agent mode \"primary\" cannot be delegated via subagent_type; use mode \"subagent\" or \"all\"`
+      warnings.push(warning)
+      warnConfig(warning)
+      reviewers.push({
+        key: resolvedCustomKey,
+        label: customDisplay || metadata.description || resolvedCustomKey,
+        source,
+        isValid: false,
+      })
+      continue
+    }
+
+    reviewers.push({
+      key: resolvedCustomKey,
+      label: customDisplay || metadata.description || resolvedCustomKey,
+      source,
+      isValid: true,
+    })
+  }
+
+  return {
+    reviewers,
+    effectiveReviewers: reviewers.filter((reviewer) => reviewer.isValid),
+    warnings,
+  }
+}

--- a/src/runtime/opencode/enabled-agent-keys.test.ts
+++ b/src/runtime/opencode/enabled-agent-keys.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "bun:test"
-import { buildEnabledAgentKeys } from "./enabled-agent-keys"
+import { describe, it, expect, spyOn } from "bun:test"
+import { buildEnabledAgentKeys, buildEffectiveAdditionalReviewerKeys } from "./enabled-agent-keys"
 import type { WeaveConfig } from "../../config/schema"
 
 const BUILTINS = ["loom", "tapestry", "shuttle", "pattern", "thread", "spindle", "weft", "warp"]
@@ -117,5 +117,78 @@ describe("buildEnabledAgentKeys", () => {
     const result = buildEnabledAgentKeys({})
     const categoryShuttles = [...result].filter(k => k.startsWith("shuttle-"))
     expect(categoryShuttles).toHaveLength(0)
+  })
+})
+
+describe("buildEffectiveAdditionalReviewerKeys", () => {
+  it("returns only valid enabled custom reviewers", () => {
+    const config: WeaveConfig = {
+      custom_agents: {
+        "security-reviewer": { model: "gpt-4o", display_name: "Security Reviewer" },
+        "perf-reviewer": { model: "gpt-4o" },
+        "disabled-reviewer": { model: "gpt-4o" },
+      },
+      disabled_agents: ["disabled-reviewer"],
+      review: {
+        additional_agents: [
+          "security-reviewer",
+          "perf-reviewer",
+          "security-reviewer",
+          "disabled-reviewer",
+          "missing-reviewer",
+          "weft",
+          "warp",
+        ],
+      },
+    }
+
+    const metadata = [
+      {
+        name: "security-reviewer",
+        description: "Security checks",
+        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+      },
+      {
+        name: "perf-reviewer",
+        description: "Performance checks",
+        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+      },
+    ]
+
+    const result = buildEffectiveAdditionalReviewerKeys(config, metadata)
+    expect(result.has("security-reviewer")).toBe(true)
+    expect(result.has("perf-reviewer")).toBe(true)
+    expect(result.has("disabled-reviewer")).toBe(false)
+    expect(result.has("missing-reviewer")).toBe(false)
+    expect(result.has("weft")).toBe(false)
+    expect(result.has("warp")).toBe(false)
+    expect(result.size).toBe(2)
+  })
+
+  it("emits actionable warnings for ignored entries", () => {
+    const warnSpy = spyOn(console, "error").mockImplementation(() => {})
+    const config: WeaveConfig = {
+      custom_agents: {
+        reviewer: { model: "gpt-4o" },
+      },
+      review: {
+        additional_agents: ["reviewer", "reviewer", "missing", "weft"],
+      },
+    }
+
+    const metadata = [
+      {
+        name: "reviewer",
+        description: "Reviewer",
+        metadata: { category: "advisor", cost: "EXPENSIVE", triggers: [] },
+      },
+    ]
+
+    buildEffectiveAdditionalReviewerKeys(config, metadata)
+
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("duplicate reviewer"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("custom agent not found"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("managed by built-in review flow"))).toBe(true)
+    warnSpy.mockRestore()
   })
 })

--- a/src/runtime/opencode/enabled-agent-keys.test.ts
+++ b/src/runtime/opencode/enabled-agent-keys.test.ts
@@ -118,6 +118,22 @@ describe("buildEnabledAgentKeys", () => {
     const categoryShuttles = [...result].filter(k => k.startsWith("shuttle-"))
     expect(categoryShuttles).toHaveLength(0)
   })
+
+  it("matches disabled_agents case-insensitively", () => {
+    const result = buildEnabledAgentKeys({
+      disabled_agents: ["WeFt", "Custom-Reviewer", "Shuttle-Docs"],
+      custom_agents: {
+        "custom-reviewer": { model: "gpt-4o" },
+      },
+      categories: {
+        docs: { description: "Docs work" },
+      },
+    })
+
+    expect(result.has("weft")).toBe(false)
+    expect(result.has("custom-reviewer")).toBe(false)
+    expect(result.has("shuttle-docs")).toBe(false)
+  })
 })
 
 describe("buildEffectiveAdditionalReviewerKeys", () => {

--- a/src/runtime/opencode/enabled-agent-keys.ts
+++ b/src/runtime/opencode/enabled-agent-keys.ts
@@ -16,17 +16,17 @@ const BUILTIN_AGENT_NAMES = ["loom", "tapestry", "shuttle", "pattern", "thread",
  *   `shuttle-{category}` key is not disabled
  */
 export function buildEnabledAgentKeys(pluginConfig: WeaveConfig): Set<string> {
-  const disabled = new Set(pluginConfig.disabled_agents ?? [])
+  const disabled = new Set((pluginConfig.disabled_agents ?? []).map((agent) => agent.toLowerCase()))
   const enabled = new Set<string>()
 
   for (const builtin of BUILTIN_AGENT_NAMES) {
-    if (!disabled.has(builtin)) {
+    if (!disabled.has(builtin.toLowerCase())) {
       enabled.add(builtin)
     }
   }
 
   for (const custom of Object.keys(pluginConfig.custom_agents ?? {})) {
-    if (!disabled.has(custom)) {
+    if (!disabled.has(custom.toLowerCase())) {
       enabled.add(custom)
     }
   }
@@ -36,7 +36,7 @@ export function buildEnabledAgentKeys(pluginConfig: WeaveConfig): Set<string> {
   if (shuttleEnabled && pluginConfig.categories) {
     for (const categoryName of Object.keys(pluginConfig.categories)) {
       const categoryAgentName = `shuttle-${categoryName}`
-      if (!disabled.has(categoryAgentName)) {
+      if (!disabled.has(categoryAgentName.toLowerCase())) {
         enabled.add(categoryAgentName)
       }
     }
@@ -46,11 +46,8 @@ export function buildEnabledAgentKeys(pluginConfig: WeaveConfig): Set<string> {
 }
 
 /**
- * Derives only effective additional reviewer keys from review.additional_agents.
- *
- * Notes:
- * - Excludes `weft` because it remains built-in always-on reviewer flow.
- * - Excludes `warp` because security review is resolved separately.
+ * Derives the keys for whatever resolveEffectiveReviewers considers
+ * effective additional reviewers from review.additional_agents.
  */
 export function buildEffectiveAdditionalReviewerKeys(
   pluginConfig: WeaveConfig,

--- a/src/runtime/opencode/enabled-agent-keys.ts
+++ b/src/runtime/opencode/enabled-agent-keys.ts
@@ -1,4 +1,6 @@
 import type { WeaveConfig } from "../../config/schema"
+import type { AvailableAgent } from "../../agents/dynamic-prompt-builder"
+import { resolveEffectiveReviewers } from "../../review/reviewer-resolution"
 
 const BUILTIN_AGENT_NAMES = ["loom", "tapestry", "shuttle", "pattern", "thread", "spindle", "weft", "warp"] as const
 
@@ -41,4 +43,19 @@ export function buildEnabledAgentKeys(pluginConfig: WeaveConfig): Set<string> {
   }
 
   return enabled
+}
+
+/**
+ * Derives only effective additional reviewer keys from review.additional_agents.
+ *
+ * Notes:
+ * - Excludes `weft` because it remains built-in always-on reviewer flow.
+ * - Excludes `warp` because security review is resolved separately.
+ */
+export function buildEffectiveAdditionalReviewerKeys(
+  pluginConfig: WeaveConfig,
+  customAgentMetadata: AvailableAgent[],
+): Set<string> {
+  const resolution = resolveEffectiveReviewers({ pluginConfig, customAgentMetadata })
+  return new Set(resolution.effectiveReviewers.map((reviewer) => reviewer.key))
 }

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -69,6 +69,10 @@ export function warn(message: string, data?: unknown): void {
   emit("WARN", message, data)
 }
 
+export function warnConfig(message: string, data?: unknown): void {
+  warn(`[config] ${message}`, data)
+}
+
 export function error(message: string, data?: unknown): void {
   emit("ERROR", message, data)
 }

--- a/test/integration/manager-config.integration.test.ts
+++ b/test/integration/manager-config.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { join } from "path"
 import { stripDisabledAgentReferences, resetNameVariants } from "../../src/agents/agent-builder"
 import { WeaveConfigSchema } from "../../src/config/schema"
@@ -173,5 +173,63 @@ describe("Integration: manager config", () => {
     expect(result).not.toContain("Data Validator")
     expect(result).toContain("Pipeline Lead")
     expect(result).toContain("Keep this line")
+  })
+
+  it("resolves effective additional reviewers with safe defaults and keeps Weft/Warp base review flow", () => {
+    const warnSpy = spyOn(console, "error").mockImplementation(() => {})
+    const config = WeaveConfigSchema.parse({
+      custom_agents: {
+        "security-reviewer": {
+          prompt: "Review security concerns.",
+          display_name: "Security Sentinel",
+        },
+        "perf-reviewer": {
+          prompt: "Review performance concerns.",
+          display_name: "Perf Reviewer",
+        },
+        "disabled-reviewer": {
+          prompt: "Should never run.",
+          display_name: "Disabled Reviewer",
+        },
+      },
+      disabled_agents: ["disabled-reviewer"],
+      review: {
+        additional_agents: [
+          "security-reviewer",
+          "perf-reviewer",
+          "security-reviewer",
+          "disabled-reviewer",
+          "missing-reviewer",
+          "weft",
+          "warp",
+          "loom",
+        ],
+      },
+    })
+
+    const managers = createManagers({
+      ctx: makeMockCtx(fixture.directory),
+      pluginConfig: config,
+    })
+
+    const tapestryPrompt = managers.agents["tapestry"]?.prompt ?? ""
+    expect(tapestryPrompt).toContain("Delegate to Weft")
+    expect(tapestryPrompt).toContain("Delegate to Warp")
+    expect(tapestryPrompt).toContain("Delegate to Security Sentinel")
+    expect(tapestryPrompt).toContain('subagent_type "security-reviewer"')
+    expect(tapestryPrompt).toContain('subagent_type "perf-reviewer"')
+    expect(tapestryPrompt).not.toContain('subagent_type "Security Sentinel"')
+    expect(tapestryPrompt).not.toContain('subagent_type "disabled-reviewer"')
+    expect(tapestryPrompt).not.toContain('subagent_type "missing-reviewer"')
+    expect(tapestryPrompt).not.toContain('subagent_type "loom"')
+    expect(tapestryPrompt).not.toContain('subagent_type "weft" — additional')
+    expect(tapestryPrompt).not.toContain('subagent_type "warp" — additional')
+
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("duplicate reviewer"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("agent is disabled"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("custom agent not found"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("managed by built-in review flow"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("only custom_agents keys are supported"))).toBe(true)
+    warnSpy.mockRestore()
   })
 })

--- a/test/integration/plugin-bootstrap.integration.test.ts
+++ b/test/integration/plugin-bootstrap.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { existsSync, readFileSync } from "fs"
 import { join } from "path"
 import WeavePlugin from "../../src/index"
@@ -179,5 +179,56 @@ describe("Integration: plugin bootstrap config", () => {
     expect(existsSync(join(fixture.directory, ANALYTICS_DIR))).toBe(true)
     expect(loomPrompt).not.toContain("spindle")
     expect(configObj.default_agent).toBe(loomDisplayName)
+  })
+
+  it("ignores invalid review.additional_agents references with warnings and preserves Weft/Warp safety path", async () => {
+    fixture.writeProjectConfig({
+      custom_agents: {
+        "review-custom": {
+          prompt: "Review with strict standards.",
+          display_name: "Review Sentinel",
+        },
+        "disabled-reviewer": {
+          prompt: "Should not run.",
+          display_name: "Disabled Reviewer",
+        },
+      },
+      disabled_agents: ["disabled-reviewer"],
+      review: {
+        additional_agents: [
+          "review-custom",
+          "review-custom",
+          "weft",
+          "warp",
+          "loom",
+          "missing-reviewer",
+          "disabled-reviewer",
+        ],
+      },
+    })
+
+    const warnSpy = spyOn(console, "error").mockImplementation(() => {})
+
+    const plugin = await WeavePlugin(makeMockCtx(fixture.directory))
+    const configObj: Record<string, unknown> = {}
+    await (plugin.config as (config: Record<string, unknown>) => Promise<void>)(configObj)
+
+    const agents = configObj.agent as Record<string, { prompt?: string }>
+    const tapestryPrompt = agents[getAgentDisplayName("tapestry")]?.prompt ?? ""
+
+    expect(tapestryPrompt).toContain('Delegate to Weft: subagent_type "weft"')
+    expect(tapestryPrompt).toContain('Delegate to Warp: subagent_type "warp"')
+    expect(tapestryPrompt).toContain('Delegate to Review Sentinel: subagent_type "review-custom"')
+    expect(tapestryPrompt).not.toContain('subagent_type "Review Sentinel"')
+    expect(tapestryPrompt).not.toContain('subagent_type "disabled-reviewer"')
+    expect(tapestryPrompt).not.toContain('subagent_type "missing-reviewer"')
+    expect(tapestryPrompt).not.toContain('subagent_type "loom"')
+
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("duplicate reviewer"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("managed by built-in review flow"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("only custom_agents keys are supported"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("custom agent not found"))).toBe(true)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes("agent is disabled"))).toBe(true)
+    warnSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- add `review.additional_agents` config support with explicit merge and validation behavior
- route Loom and Tapestry through multi-review collection, comparison, and synthesis without changing the default Weft/Warp flow
- expand tests and eval contracts for legacy and opt-in multi-reviewer review paths

## Example usage
```jsonc
{
  "custom_agents": {
    "review-kimi": {
      "prompt": "Review changes with focus on edge cases and regressions.",
      "model": "openai/gpt-5.4",
      "mode": "subagent",
      "display_name": "Review Kimi"
    },
    "review-glm": {
      "prompt": "Review changes with focus on clarity and maintainability.",
      "model": "openai/gpt-5.4",
      "mode": "all",
      "display_name": "Review GLM"
    }
  },
  "review": {
    "additional_agents": ["review-kimi", "review-glm"]
  }
}
```

With this config:
- `weft` remains the default reviewer
- Loom/Tapestry also run `review-kimi` and `review-glm`
- final review synthesis is reported in `consensus`, `discrepancies`, and `unique findings`
- `warp` remains mandatory for security-sensitive changes

## Notes
- `review.additional_agents` only accepts explicit `custom_agents` keys
- invalid, duplicate, disabled, or `mode: "primary"` reviewers are ignored with warnings
- project config can clear inherited reviewers with:
  ```jsonc
  { "review": { "additional_agents": [] } }
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for configuring additional reviewers via `review.additional_agents` in weave configuration.
  * Loom and Tapestry agents now support multiple reviewers with structured review workflows including collection, comparison, and synthesis phases.
  * Enhanced review process to explicitly track consensus, discrepancies, and unique findings across reviewers.

* **Documentation**
  * Configuration reference extended with `review.additional_agents` specification and merge semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->