### PR TITLE
feat(review): orchestrate reviewer fanout via runtime

### DIFF
--- a/.weave/plans/multi-model-review.md
+++ b/.weave/plans/multi-model-review.md
@@ -1,0 +1,117 @@
+# Multi-Model Adversarial Review
+
+## TL;DR
+> **Summary**: Add `review_models` config to warp/weft agents, enabling parallel multi-model review with automatic collation. When configured, `call_weave_agent` targeting warp/weft spawns additional reviewer sessions in parallel, then collates all outputs via the primary model.
+> **Estimated Effort**: Medium
+
+## Context
+### Original Request
+Enable adversarial multi-model review for warp (security) and weft (code review) agents. Multiple LLMs review the same code independently, then results are merged — reducing false negatives.
+
+### Key Findings
+- **Agent invocation**: Warp/weft are invoked via `call_weave_agent` tool (SDK-provided). They run as subagent sessions.
+- **Hook system**: `tool.execute.after` hook receives mutable `output: { title, output, metadata }` — this is the interception point. Currently Weave ignores the `output` param in `handleToolExecuteAfter` (passes `_output`).
+- **SDK session API**: `client.session.create` creates sessions, `client.session.promptAsync` sends prompts with `agent` and `model` overrides, `client.session.prompt` waits synchronously. `session.get` can poll status.
+- **Agent config**: `AgentOverrideConfigSchema` in `src/config/schema.ts` holds per-agent overrides. Adding `review_models: string[]` here is the config surface.
+- **Warp/weft defaults**: Both are read-only (tools: `{ write: false, edit: false, task: false, call_weave_agent: false }`), temperature 0.1, mode "subagent".
+- **Config flow**: `createBuiltinAgents` in `builtin-agents.ts` reads `agentOverrides` and applies them. The override config is available at agent creation time but NOT at tool-execution time — the orchestrator needs access to the resolved config.
+
+## Objectives
+### Core Objective
+When `review_models` is configured for warp or weft, run all models as parallel reviewers and return a collated result — transparently to callers.
+
+### Deliverables
+- [ ] `review_models` config field on `AgentOverrideConfigSchema`
+- [ ] Review orchestrator module at `src/agents/review-orchestrator.ts`
+- [ ] Hook integration in plugin adapter's `tool.execute.after`
+- [ ] Collation prompt and LLM call
+- [ ] Tests for orchestrator, config, and integration
+
+### Definition of Done
+- [ ] `bun test` passes with no regressions
+- [ ] Single-model warp/weft behavior unchanged when `review_models` is absent
+- [ ] With `review_models` configured, multiple reviewer outputs are collated into one
+- [ ] Failed reviewers produce warnings but don't block the review
+
+### Guardrails (Must NOT)
+- Must NOT change behavior when `review_models` is unconfigured
+- Must NOT modify warp/weft agent prompts or defaults
+- Must NOT add agent-specific logic to the collation prompt
+- Must NOT block if all additional reviewers fail (primary still succeeds)
+
+## TODOs
+
+- [x] 1. **Add `review_models` to config schema**
+  **What**: Add `review_models: z.array(z.string()).optional()` to `AgentOverrideConfigSchema`. Update the `AgentOverrideConfig` type export.
+  **Files**: `src/config/schema.ts`
+  **Acceptance**: Schema accepts `{ agents: { warp: { review_models: ["anthropic/claude-sonnet-4-20250514"] } } }` and rejects non-string arrays. Existing configs without `review_models` parse unchanged.
+
+- [x] 2. **Create review orchestrator module**
+  **What**: New module that:
+    - Takes: agent name, primary review output, review prompt/context, list of `review_models`, SDK client reference
+    - Creates N sessions (one per review model) via `client.session.create`
+    - Sends the same prompt to each via `client.session.promptAsync` with `model` override
+    - Polls `client.session.get` for completion (with timeout)
+    - Returns array of `{ model: string, output: string, success: boolean, error?: string }`
+    - Uses `Promise.allSettled` for parallel execution with per-reviewer timeouts
+  **Files**: `src/agents/review-orchestrator.ts`
+  **Acceptance**: Unit tests with mocked SDK client verify parallel execution, timeout handling, and partial failure.
+
+- [x] 3. **Create collation prompt and runner**
+  **What**: Generic collation function that:
+    - Builds a prompt containing: all reviewer outputs (labeled by model), the original context, notes on failed reviewers
+    - Instructions: merge, deduplicate, err toward inclusion, match input review format
+    - Calls the primary model via `client.session.prompt` (or a new ephemeral session)
+    - Returns the collated text
+  **Files**: `src/agents/review-orchestrator.ts` (same module, exported `collateReviews` function)
+  **Acceptance**: Unit test verifies prompt construction includes all reviewer outputs and failure notes. Collation prompt is agent-agnostic.
+
+- [x] 4. **Wire orchestrator into plugin adapter**
+  **What**:
+    - In `createPluginAdapter`, pass `agentOverrides` config (or just the resolved `review_models` map) to the adapter
+    - In `handleToolExecuteAfter`: when tool is `call_weave_agent`, agent is warp/weft, and `review_models` is configured:
+      1. Extract the primary review output from `output.output`
+      2. Extract the original prompt from `input.args`
+      3. Call orchestrator to run additional reviewers in parallel
+      4. Call collation with primary + additional outputs
+      5. Replace `output.output` with collated result
+      6. Update `output.title` to indicate multi-model review (e.g., "Weft Review (3 models)")
+    - Update `handleToolExecuteAfter` signature to accept and use the mutable `output` param (currently `_output`)
+    - When unconfigured: no change to existing flow
+  **Files**: `src/runtime/opencode/plugin-adapter.ts`, `src/plugin/plugin-interface.ts`
+  **Acceptance**: Integration test with mocked client verifies: (a) orchestrator not called when `review_models` absent, (b) orchestrator called and output replaced when configured, (c) warning surfaced when reviewer fails.
+
+- [x] 5. **Surface reviewer failure warnings**
+  **What**: When N of M additional reviewers fail, prepend warning to collated output: `⚠️ {N} of {M} additional review models did not respond. Results based on {M-N+1} models (including primary).` If ALL additional reviewers fail, skip collation entirely and return primary output with warning: `⚠️ All {M} additional review models failed. Showing primary model review only.`
+  **Files**: `src/agents/review-orchestrator.ts`
+  **Acceptance**: Tests verify warning text for partial and total failure scenarios.
+
+- [x] 6. **Pass config context to adapter**
+  **What**: The adapter needs to know which agents have `review_models` configured. Thread the `agentOverrides` (or a derived `reviewModelsMap: Record<string, string[]>`) from `createPluginAdapter` args through to `handleToolExecuteAfter`. The `createPluginAdapter` already receives `pluginConfig` which contains `agents` overrides.
+  **Files**: `src/runtime/opencode/plugin-adapter.ts`
+  **Acceptance**: `handleToolExecuteAfter` can look up `review_models` for the target agent.
+
+- [x] 7. **Unit tests for review orchestrator**
+  **What**: Test file covering:
+    - Happy path: 2 additional reviewers succeed, collation merges 3 outputs
+    - Partial failure: 1 of 2 additional reviewers fails, collation uses 2 outputs + warning
+    - Total failure: all additional reviewers fail, returns primary output + warning
+    - Timeout: reviewer exceeds timeout, treated as failure
+    - Empty `review_models`: orchestrator not invoked
+  **Files**: `src/agents/review-orchestrator.test.ts`
+  **Acceptance**: All tests pass with `bun test src/agents/review-orchestrator.test.ts`
+
+- [x] 8. **Integration test for plugin adapter hook**
+  **What**: Test that `tool.execute.after` for `call_weave_agent` targeting weft/warp with `review_models` configured triggers orchestration and modifies output. Test that without `review_models`, output is untouched.
+  **Files**: `src/plugin/plugin-interface.test.ts` (add cases to existing test file)
+  **Acceptance**: Tests pass, no regressions in existing plugin-interface tests.
+
+- [x] 9. **JSON schema regeneration**
+  **What**: If the project auto-generates JSON schema from Zod (check `schema/` directory), regenerate to include `review_models`.
+  **Files**: `schema/` (if applicable)
+  **Acceptance**: JSON schema includes `review_models` property under agent overrides.
+
+## Verification
+- [x] `bun test` — all tests pass, no regressions
+- [x] Config without `review_models` produces identical behavior (grep for `review_models` in runtime paths confirms early-exit)
+- [ ] Manual test: configure `review_models: ["anthropic/claude-sonnet-4-20250514"]` on weft, invoke weft review, observe collated output

--- a/.weave/plans/robust-review-orchestration.md
+++ b/.weave/plans/robust-review-orchestration.md
@@ -1,0 +1,451 @@
+# Robust Review Orchestration — Runtime-Deterministic Reviewer Fan-Out
+
+## TL;DR
+> **Summary**: Move reviewer fan-out from the LLM into the Weave runtime, with a single semantic for both direct `@weft`/`@warp` invocations and Tapestry's post-execution review. The runtime resolves the reviewer set from config, runs the variants (and, in post-execution, the base too), collates results, and posts a single output back. The foreground turn provides the primary output in direct scope; the runtime executes everything in post-execution scope. No double-execution. No LLM-authored Task fan-out.
+> **Estimated Effort**: Large
+
+## Context
+
+### Original Request
+Loom/Tapestry today let the LLM decide whether a direct `@weft` turn fans out to the `weft-review-*` variants configured via `agents.weft.review_models`. That is non-deterministic. We want: when the intent and the review target are clear (`@weft`/`@warp`, or Tapestry's post-execution gate), the runtime resolves the reviewer set from config and *executes* base + variants without asking the model and without asking the user. Keep the Weft/Warp boundary in code. Fall back cleanly when variants are missing or agents are disabled. Ship evals/tests that fit the current harness, extending it only where called out.
+
+### Key Findings
+- **`buildReviewModelVariants`** (`src/agents/review-model-variants.ts`) already produces the canonical `ReviewModelVariant[]` from `agents.weft/warp.review_models`, applies the Weft/Warp boundary at key/label level, and filters disabled agents per variant.
+- **`runAdditionalReviewers` + `collateReviews` + `buildFailureWarning`** in `src/agents/review-orchestrator.ts` are implemented and unit-tested but **dead** — no production caller. Today's signature takes a single `agentName: string` for all reviewers; we extend it to accept `{ agentName, model }[]` so the visible variant agents (`weft-review-opencode-go-...`) can each carry their own boundary prompt.
+- **`pluginConfig.agents` is already in scope of `createPluginAdapter`** (`src/runtime/opencode/plugin-adapter.ts` lines 23–38). The adapter can precompute reviewer plans and pass them to the lifecycle policy or emit effects directly from `routeRuntimeEvent`.
+- **Foreground agent is already tracked**: `executionLeaseRepository.readSessionRuntime(directory, sessionId)?.foreground_agent` (`src/domain/session/execution-lease.ts`, exercised in `plan-execution.ts` and `workflow-service.ts`). `chat.params` already writes it (`plugin-adapter.ts` lines 159–171). Reading it is the canonical way to know "is the user talking to Weft right now?" without changing any input shape.
+- **`onAssistantMessage` lifecycle hook exists** (`src/application/policy/runtime-policy.ts` line 89; fired from `message.updated` for `info.role === "assistant"` in `event-router.ts` line 110). Today its input (`RuntimeAssistantMessageInput`) is minimal: `{ sessionId, hooks, inputTokens }`. We extend it with `directory`, the resolved foreground agent, and the assistant text — all already available in the router (`state.lastAssistantMessageText`, `executionLeaseRepository.readSessionRuntime`).
+- **`onSessionIdle` already detects plan-complete** and emits the verification reminder (`src/application/policy/verification-session-policy.ts`). It writes `verification_reminder_sent` to work state so it fires exactly once. The new reviewer fan-out for Tapestry post-execution lives next to it as a sibling session policy.
+- **Composer gates short-circuit when no variants are configured**: `createLoomAgentWithOptions` (`src/agents/loom/index.ts` line 24) and `createTapestryAgentWithOptions` (`src/agents/tapestry/index.ts` line 22) both return the static `*_DEFAULTS.prompt` when `reviewModelVariants` is empty and nothing else applies. Any "unconditional advisory" inserted by composers would NOT be rendered in the no-variant baseline. The plan **changes the gate** so the advisory is unconditional (because in the new world, runtime fan-out is the source of truth and the advisory is short, cheap, and useful even when no variants exist — it explains why the user does not see fan-out happen).
+- **Plugin-interface contract being changed**: `src/plugin/plugin-interface.test.ts` lines 1385–1500 currently assert that `tool.execute.after` for `call_weave_agent`/`task` with `review_models` set leaves output unchanged and makes no `session.create`/`session.prompt` calls. We keep those guarantees for `tool.execute.after` (fan-out doesn't live there anymore), but we add new tests asserting fan-out happens via `chat.params` + `message.updated` (`onAssistantMessage`) for direct scope and via `session.idle` (`onSessionIdle`) for post-execution scope.
+- **Eval harness limits**: `BuiltinAgentPromptVariantSchema` (`src/features/evals/schema.ts` line 26) accepts only `disabledAgents` and `categories` today. Adding `agentOverrides` is a small additive change. `trajectory-run` is mock-canned and **cannot prove** runtime fan-out — that contract lives in `plugin-interface.test.ts` and `session-policy.test.ts`.
+
+## Objectives
+
+### Core Objective
+A direct `@weft`/`@warp` turn and a Tapestry post-execution review trigger the **same** runtime-driven reviewer fan-out derived from config. The model never authors the Task calls. In direct scope, the foreground turn IS the base/primary reviewer — the runtime only spawns variants and collates. In post-execution scope, the runtime spawns base + variants because Tapestry itself is the foreground turn, not the reviewer.
+
+### Final Semantics (Single Source of Truth)
+
+| Scope | What the foreground turn does | What the runtime does |
+|---|---|---|
+| **direct** + `kind: "fan-out"` (variants configured) | Foreground Weft/Warp produces the primary review output normally | After foreground turn finalises, capture its text as `primaryOutput`; spawn `N` variant sessions in parallel; collate `primary + variants` into one assistant message injected back into the session |
+| **direct** + `kind: "primary-only"` (no variants, agent enabled) | Foreground Weft/Warp produces the review | No fan-out. **Zero extra `session.create` calls** (the foreground turn already executed the base reviewer). The foreground output IS the final output. |
+| **direct** + `kind: "disabled"` | N/A — the agent doesn't exist; opencode cannot route a direct turn to it | No fan-out. |
+| **post-execution** + `kind: "fan-out"` (variants configured) | Tapestry detects plan complete | Spawn `1 + N` sessions (base reviewer + each variant) in parallel, collate, post a single review verdict back via `injectPromptAsync` so Tapestry sees it as a user-style turn |
+| **post-execution** + `kind: "primary-only"` (no variants, agent enabled) | Tapestry detects plan complete | Spawn **exactly one** runtime base-reviewer session (no foreground turn covers it in this scope; Tapestry is the foreground). No collation. **1 extra `session.create` call.** |
+| **post-execution** + `kind: "disabled"` | Tapestry detects plan complete | No fan-out for that base agent. Existing verification reminder still fires. |
+
+This resolves Blocker 1: "base always runs except when disabled" is preserved, but who *executes* the base depends on scope — the foreground turn covers it in direct scope, the runtime covers it in post-execution scope. Either way the base runs exactly once.
+
+### Deliverables
+- [x] `ReviewerPlan` discriminated union + pure `resolveReviewers()` in `src/agents/review-resolver.ts` (new file).
+- [x] Extend `runAdditionalReviewers` to accept `{ agentName, model }[]` entries plus updated tests.
+- [x] New `runReviewerFanOut()` runtime helper in `src/agents/review-orchestrator.ts` consuming a `ReviewerPlan` plus a `primaryOutput` (captured) OR running base-and-variants depending on scope.
+- [x] New `runReviewerFanOut` runtime effect type wired through `effects.ts` and `apply-effects.ts`.
+- [x] Extend `RuntimeAssistantMessageInput` with `directory`, `foregroundAgent`, `assistantText`, `originalPromptText`, `messageId` (all available in `event-router.ts` via `state.lastAssistantMessageText`, `state.lastUserMessageText`, the execution lease, and the event payload).
+- [x] New session policy `createDirectReviewerFanOutSessionPolicy(deps)` triggered on `onAssistantMessage` for direct scope (consumes foreground text as `primaryOutput`).
+- [x] New session policy `createPostExecutionReviewerFanOutSessionPolicy(deps)` triggered on `onSessionIdle` for post-execution scope (runs base + variants from scratch).
+- [x] Thread `pluginConfig.agents` (or a derived `Record<"weft"|"warp", ReviewerPlan>` cache) into `createRuntimeLifecyclePolicySurface` and through to the two new session policies. This resolves Blocker 3.
+- [x] Loom + Tapestry composers: **unconditional one-line advisory** ("runtime fans out automatically when `review_models` are configured"). Gates in `loom/index.ts` and `tapestry/index.ts` updated so the advisory is rendered even in the no-variant baseline (the composer always runs).
+- [x] Updated `plugin-interface.test.ts` lines 1385–1500: the three existing tests stay green (they assert `tool.execute.after` does not mutate output and does not spawn sessions); new tests assert fan-out via the new entry points.
+- [x] Harness extension: add `agentOverrides` to `BuiltinAgentPromptVariantSchema` and thread it through `resolveBuiltinAgentTarget`.
+- [x] New `prompt-render` eval cases for advisory copy (with and without variants, with disabled reviewers, boundary).
+
+### Definition of Done
+- [x] `bun test` passes.
+- [x] `bun run eval --suite prompt-contracts` passes.
+- [x] Given `agents.weft = { model: "openai/gpt-5.5", review_models: ["opencode-go/kimi-k2.6"] }`, a direct `@weft` turn produces:
+  - The user's foreground Weft turn runs normally (1 turn).
+  - After `message.updated` fires for that assistant message, the runtime spawns **exactly 1** variant session + **1** collation session (total 2 extra `session.create` calls beyond the foreground turn).
+  - One collated message is posted back via `promptAsync`.
+- [ ] Given the same Weft config with `review_models = []` (or omitted): a direct `@weft` turn produces **zero** extra `session.create` calls beyond the foreground turn (direct + `primary-only` is foreground-covered). On Tapestry plan-complete the same Weft config produces **exactly one** runtime `session.create` call for the Weft base reviewer (post-execution + `primary-only` is runtime-executed); zero collation calls.
+- [ ] Given Tapestry plan-complete with `agents.weft.review_models = ["opencode-go/kimi-k2.6"]`, `agents.warp = { ... }` (no warp variants), the runtime emits:
+  - For Weft: 1 base + 1 variant + 1 collation = 3 `session.create` calls.
+  - For Warp: 1 base + 0 variants = 1 `session.create` call.
+  - Followed (or preceded, deterministic ordering) by the verification reminder via `injectPromptAsync`.
+- [ ] With `disabledAgents = ["weft"]`, neither direct nor post-execution scope produces any Weft-related `session.create` calls.
+- [ ] No `weft-review-*` ever runs on a Warp plan and vice versa.
+
+### Guardrails (Must NOT)
+- Must NOT re-execute the foreground Weft/Warp turn in direct scope. The foreground turn IS the primary; the runtime adds variants + collation only.
+- Must NOT spawn fan-out before the foreground assistant message has finalised. Direct scope hook is `onAssistantMessage` (fired by `message.updated`), not `chat.message` (fires *before* the model responds). Resolves Blocker 5.
+- Must NOT mutate `tool.execute.after` output for `call_weave_agent`/`task`. The existing contract in `plugin-interface.test.ts` lines 1385–1500 stays — fan-out moved elsewhere, not relocated inside `tool.execute.after`.
+- Must NOT cross the Weft/Warp boundary at any layer.
+- Must NOT introduce a user-facing confirmation prompt for direct or post-execution fan-out.
+- Must NOT break renderings when `review_models` is absent — composers must produce a prompt that still parses every existing prompt-contract assertion, modulo the new advisory line (which all existing contracts will be updated to tolerate via `excludes-all` rather than equality).
+- Must NOT delete `runAdditionalReviewers` / `collateReviews` / `buildFailureWarning`. Extend them.
+- Must NOT add new evaluator kinds in this plan. Only extend `BuiltinAgentPromptVariantSchema` (additive).
+- Must NOT have direct-scope fan-out double-fire on follow-up turns. After fan-out emits once for a given assistant message, dedupe by `(sessionId, messageId)` so the next user turn (which also fires `onAssistantMessage` after Weft responds) is treated as a fresh review.
+
+## TODOs
+
+### Phase A — Resolver and types (pure code, no runtime)
+
+- [x] 1. **Define `ReviewerPlan` and `resolveReviewers`**
+  **What**: Create `src/agents/review-resolver.ts`. Export `type ReviewBaseAgent = "weft" | "warp"`. Discriminated union:
+  ```ts
+  export type ReviewerPlan =
+    | { kind: "fan-out"; scope: "direct" | "post-execution"; baseAgent: ReviewBaseAgent;
+        primary: { agentName: ReviewBaseAgent; label: "Weft"|"Warp"; model: string };
+        variants: ReviewModelVariant[];
+        batch: { mode: "parallel"; size: number /* 1 + variants.length */ } }
+    | { kind: "primary-only"; scope: "direct" | "post-execution"; baseAgent: ReviewBaseAgent;
+        primary: { agentName: ReviewBaseAgent; label: "Weft"|"Warp"; model: string };
+        reason: "no-variants" | "all-variants-disabled" }
+    | { kind: "disabled"; scope: "direct" | "post-execution"; baseAgent: ReviewBaseAgent;
+        reason: "agent-disabled" }
+  ```
+  Pure function:
+  ```ts
+  resolveReviewers(input: {
+    scope: "direct" | "post-execution"
+    baseAgent: ReviewBaseAgent
+    agentOverrides: Record<string, AgentOverrideConfig> | undefined
+    disabledAgents: Set<string>
+    primaryModel: string // caller passes the resolved primary model
+  }): ReviewerPlan
+  ```
+  Logic:
+  1. If `disabledAgents.has(baseAgent)` → `disabled`.
+  2. `allVariants = reviewVariantsFor(buildReviewModelVariants(agentOverrides, disabledAgents), baseAgent)`.
+  3. `rawConfigured = (agentOverrides?.[baseAgent]?.review_models ?? []).filter(m => m !== agentOverrides[baseAgent]?.model)`.
+  4. If `rawConfigured.length === 0` → `primary-only` with `reason: "no-variants"`.
+  5. If `rawConfigured.length > 0 && allVariants.length === 0` → `primary-only` with `reason: "all-variants-disabled"`.
+  6. Else → `fan-out`.
+  No I/O, no async. **Do not import** `review-orchestrator.ts` (avoids dragging the runtime into composers).
+  **Files**: `src/agents/review-resolver.ts`
+  **Acceptance**: `tsc --noEmit` clean.
+
+- [x] 2. **Unit tests for `resolveReviewers`**
+  **What**: `src/agents/review-resolver.test.ts` covering:
+  - (a) `direct` + Weft + two `review_models` → `fan-out`, variants in config order, `batch.size === 3`.
+  - (b) `direct` + Warp + one `review_models` → `fan-out`, only `warp-*` keys.
+  - (c) `direct` + Weft + `disabledAgents = ["weft"]` → `disabled`.
+  - (d) `direct` + Weft + empty `review_models` → `primary-only`, `reason: "no-variants"`.
+  - (e) `direct` + Weft + `review_models = ["opencode-go/x"]` + `disabledAgents = ["weft-review-opencode-go-x"]` → `primary-only`, `reason: "all-variants-disabled"`.
+  - (f) `review_models` containing the primary model is filtered out (`buildReviewModelVariants` already does this); when that was the only entry → `primary-only` with `reason: "no-variants"`.
+  - (g) Weft plan never contains `warp-*` variants even if `agents.warp.review_models` is set.
+  - (h) `post-execution` is structurally identical to `direct` for the same inputs; only `scope` differs.
+  **Files**: `src/agents/review-resolver.test.ts`
+  **Acceptance**: `bun test src/agents/review-resolver.test.ts` green.
+
+### Phase B — Extend `runAdditionalReviewers` and add `runReviewerFanOut`
+
+- [x] 3. **Extend `runAdditionalReviewers` to accept per-reviewer agent names**
+  **What**: Change the signature in `src/agents/review-orchestrator.ts`:
+  ```ts
+  export interface ReviewerEntry { agentName: string; model: string }
+  export interface RunAdditionalReviewersInput {
+    reviewers: ReviewerEntry[]
+    prompt: string
+    client: PluginContext["client"]
+  }
+  ```
+  Update `runSingleReviewer` to take `agentName` from the entry rather than from the top-level input. **Keep a back-compat overload** that accepts the old `{ agentName: string; reviewModels: string[] }` shape and adapts it to the new shape; mark it `@deprecated`. This avoids forcing every caller (including the existing test) to migrate in the same PR.
+  Resolves Blocker 2.
+  **Files**: `src/agents/review-orchestrator.ts`
+  **Acceptance**: Existing `runAdditionalReviewers` tests pass via the back-compat overload. New tests (next step) exercise the per-reviewer form.
+
+- [x] 4. **Tests for per-reviewer-agent form**
+  **What**: Extend `src/agents/review-orchestrator.test.ts` with:
+  - Each entry's `prompt` body carries the entry's `agentName` (assert via mock `prompt` capturing the request body).
+  - Two variants with different `agentName`s produce two distinct `client.session.create` titles (verify via mock).
+  - Old-shape input still routes through the back-compat adapter and produces identical output to today.
+  **Files**: `src/agents/review-orchestrator.test.ts`
+  **Acceptance**: Green.
+
+- [x] 5. **Add `runReviewerFanOut` runtime helper**
+  **What**: New exported async function in `review-orchestrator.ts`:
+  ```ts
+  export async function runReviewerFanOut(input: {
+    plan: ReviewerPlan
+    /** Direct scope: the captured foreground assistant verdict. Used ONLY as collation primary input. Never sent to variants. */
+    capturedPrimaryOutput?: string
+    /** The review target — the user's original request (direct) or plan-complete context (post-execution). Sent to every variant + collation. */
+    promptText: string
+    originalContext: string
+    client: PluginContext["client"]
+  }): Promise<{ output: string; failureWarning: string | null; ran: string[] }>
+  ```
+  Behavior:
+  - `plan.kind === "disabled"`: return `{ output: "", failureWarning: null, ran: [] }`.
+  - `plan.kind === "primary-only" && plan.scope === "direct"` (`capturedPrimaryOutput` must be provided): return `{ output: capturedPrimaryOutput!, failureWarning: null, ran: [plan.primary.agentName] }` — **no extra session calls**, because the foreground turn already executed the base reviewer.
+  - `plan.kind === "primary-only" && plan.scope === "post-execution"` (`capturedPrimaryOutput` must be `undefined`): call `runAdditionalReviewers` with `reviewers: [{ agentName: plan.primary.agentName, model: plan.primary.model }]` and `prompt: promptText`. Return the single result. **Exactly one `session.create` call**, no collation.
+  - `plan.kind === "fan-out"`:
+    - Build `variantEntries = plan.variants.map(v => ({ agentName: v.key, model: v.model }))`.
+    - If `plan.scope === "direct"` (`capturedPrimaryOutput` provided): call `runAdditionalReviewers` with `reviewers: variantEntries` and `prompt: promptText` (variants review the original request, NOT the primary's verdict). Then call `collateReviews({ primaryModel: plan.primary.model, primaryOutput: capturedPrimaryOutput!, additionalResults, originalContext, ... })`.
+    - If `plan.scope === "post-execution"` (`capturedPrimaryOutput` is `undefined`): call `runAdditionalReviewers` with `reviewers: [{ agentName: plan.primary.agentName, model: plan.primary.model }, ...variantEntries]` and `prompt: promptText`. First result is primary; rest are additional.
+    - In both fan-out branches: build `failureWarning` via `buildFailureWarning`. If all reviewers (primary + variants) failed → return `{ output: "", failureWarning, ran: [] }`. If primary succeeded but all variants failed → return primary output + warning, **no collation**. Otherwise collate and prepend warning when partial failure.
+  Resolves Blocker 4 (direct scope never re-runs the primary) and the per-review nit (variants always see the original request, never the primary's verdict).
+  **Files**: `src/agents/review-orchestrator.ts`
+  **Acceptance**: Tests in next step.
+
+- [x] 6. **Tests for `runReviewerFanOut`**
+  **What**: New `describe` block in `src/agents/review-orchestrator.test.ts`:
+  - `fan-out` + direct scope + `capturedPrimaryOutput`: zero `session.create` calls for the primary; N for variants; 1 for collation. **Each variant's prompt body contains `promptText` (the original request), NOT `capturedPrimaryOutput`** (assert via mock capture). Collation receives `capturedPrimaryOutput` verbatim as `primaryOutput`.
+  - `fan-out` + post-execution scope: 1 + N + 1 `session.create` calls. Each reviewer's prompt body contains `promptText` (no `capturedPrimaryOutput` is passed).
+  - `primary-only` + direct scope + `capturedPrimaryOutput`: zero `session.create` calls; output equals captured text; `ran: [plan.primary.agentName]`.
+  - `primary-only` + post-execution scope (no `capturedPrimaryOutput`): exactly 1 `session.create` + 1 `session.prompt`; no collation; reviewer's prompt body contains `promptText`.
+  - `disabled` (either scope): zero calls; `ran: []`.
+  - `fan-out` direct + 1 variant fails: failureWarning set; collation called with partial variant input + the captured primary.
+  - `fan-out` post-execution + primary fails + 1 of 2 variants succeeds: still collates with surviving variant + warning.
+  - `fan-out` post-execution + all fail: returns empty output + warning; collation NOT called.
+  - Boundary regression: when `plan.kind === "primary-only" && plan.scope === "direct"` but `capturedPrimaryOutput` is missing → return `{ output: "", failureWarning: null, ran: [] }` (defensive; caller must always pass it for direct scope, but helper does not crash).
+  **Files**: `src/agents/review-orchestrator.test.ts`
+  **Acceptance**: Green.
+
+### Phase C — Runtime effect
+
+- [x] 7. **Add `runReviewerFanOut` effect**
+  **What**: Append to `src/runtime/opencode/effects.ts`:
+  ```ts
+  export interface RunReviewerFanOutEffect {
+    type: "runReviewerFanOut"
+    sessionId: string
+    plan: ReviewerPlan
+    capturedPrimaryOutput?: string  // present in direct scope only — used by collation, never sent to variants
+    promptText: string              // the ORIGINAL user request (direct scope) or plan-complete context (post-execution scope) — this is what variants independently review
+    originalContext: string         // changed files / plan name / additional context for collation
+    /** Idempotency token. Direct scope: `${sessionId}:${messageId}`. Post-execution: `${sessionId}:${planSha}:${baseAgent}`. */
+    idempotencyKey: string
+    /** Delivery primitive — reuses the existing `injectPromptAsync` runtime effect path in `apply-effects.ts` (posts to the originating session via `client.session.promptAsync`). */
+    delivery: { kind: "injectPromptAsync" }
+  }
+  ```
+  Add to the union.
+  **Files**: `src/runtime/opencode/effects.ts`
+  **Acceptance**: Type-checks; existing apply-effects test still compiles.
+
+- [x] 8. **Implement effect in `apply-effects.ts`**
+  **What**: New `case "runReviewerFanOut"`:
+  1. Maintain a per-adapter `Set<string>` of seen `idempotencyKey`s; bail if seen. This dedupes the cascading `onAssistantMessage` that fires for the collation message itself.
+  2. Call `runReviewerFanOut({ plan, capturedPrimaryOutput, promptText, originalContext, client })`.
+  3. If `output` is non-empty, deliver via the existing `injectPromptAsync` path — either by emitting a nested `injectPromptAsync` effect (preferred: reuses `createSessionClient(client).promptAsync(...)` so we keep one delivery primitive in the codebase) or by calling `client.session.promptAsync({ path: { id: sessionId }, body: { parts: [{ type: "text", text: output }] } })` inline. The text MUST be tagged with a sentinel header (`<!-- weave:reviewer-fanout -->`) so the dedupe step in (1) can also use the tag as a belt-and-suspenders signal.
+  4. If `failureWarning` is non-empty, prepend it to the output before the sentinel-tagged delivery.
+  5. Catch and log; do not throw — the user's session must not be blocked by reviewer failure. Idempotency entries are recorded even on failure to prevent retry storms.
+  **Files**: `src/runtime/opencode/apply-effects.ts`, `src/runtime/opencode/apply-effects.test.ts`
+  **Acceptance**: New apply-effects tests with a stub client assert: in fan-out + direct scope with `capturedPrimaryOutput`, `session.create` is called exactly `variants + 1 (collation)` times; in fan-out + post-execution, `1 + variants + 1` times; in primary-only + post-execution, exactly 1 `session.create`; in primary-only + direct, exactly 0 `session.create` calls; idempotency key dedupes the second invocation; the final delivery to the originating session uses `promptAsync` (the same primitive used by `injectPromptAsync`).
+
+### Phase D — Plumbing: extend lifecycle inputs and policies
+
+- [x] 9. **Extend `RuntimeAssistantMessageInput`**
+  **What**: In `src/application/policy/runtime-policy.ts`:
+  ```ts
+  export interface RuntimeAssistantMessageInput {
+    sessionId: string
+    hooks: RuntimePolicyFlags
+    inputTokens: number
+    // NEW
+    directory: string
+    foregroundAgent?: string | null  // resolved from session runtime
+    assistantText?: string           // latest accumulated assistant text — used ONLY as capturedPrimaryOutput for collation
+    originalPromptText?: string      // latest user request text in this session — used as the review target sent to variants
+    messageId?: string               // for idempotency
+  }
+  ```
+  Update `event-router.ts` (the `message.updated` branch) to populate these from `state.lastAssistantMessageText`, `state.lastUserMessageText` (already maintained by the adapter and threaded into `EventRouterState`; today only `onSessionIdle` reads it — extend `onAssistantMessage` to read it the same way), `executionLeaseRepository.readSessionRuntime(directory, sessionId)?.foreground_agent`, and the event's `info.id`. Pass `directory` from the router's input. Update `RuntimeLifecyclePolicySurface.onAssistantMessage` callers if any signature break occurs. Resolves Blocker 3 + Blocker 5.
+  **Rationale**: `assistantText` is the reviewer's primary verdict; `originalPromptText` is the *request the user made* — what the variants must independently review. Without this separation, variants would review the primary reviewer's text instead of the original target, defeating multi-model review.
+  **Files**: `src/application/policy/runtime-policy.ts`, `src/runtime/opencode/event-router.ts`, `src/application/policy/context-window-session-policy.ts` (extend its input use), `src/application/policy/policy-engine.ts` (no changes expected — pass-through)
+  **Acceptance**: `bun test src/runtime/opencode/event-router.test.ts` + `src/application/policy/policy-engine.test.ts` + `src/application/policy/session-policy.test.ts` green; new assertion in the event-router test confirms `onAssistantMessage` receives both `assistantText` and `originalPromptText`.
+
+- [x] 10. **Thread review config into the lifecycle factory**
+  **What**: Change `createRuntimeLifecyclePolicySurface(args)` (`src/application/orchestration/session-runtime.ts`) to accept a new optional dep:
+  ```ts
+  reviewerResolver?: {
+    forBaseAgent(baseAgent: "weft"|"warp", scope: "direct"|"post-execution"): ReviewerPlan
+  }
+  ```
+  In `createPluginAdapter` (`plugin-adapter.ts`), build that resolver once at adapter construction:
+  ```ts
+  const disabledSet = new Set(/* from enabledAgents diff */)
+  const reviewerResolver = {
+    forBaseAgent(baseAgent, scope) {
+      const overrides = pluginConfig.agents
+      const primaryModel = overrides?.[baseAgent]?.model ?? /* fall back to default model resolution */
+      return resolveReviewers({ scope, baseAgent, agentOverrides: overrides, disabledAgents: disabledSet, primaryModel })
+    },
+  }
+  ```
+  Pass `reviewerResolver` into `createRuntimeLifecyclePolicySurface`. Resolves Blocker 3.
+  **Files**: `src/application/orchestration/session-runtime.ts`, `src/runtime/opencode/plugin-adapter.ts`
+  **Acceptance**: Compiles; existing surface tests unchanged.
+
+- [x] 11. **`createDirectReviewerFanOutSessionPolicy`**
+  **What**: New file `src/application/policy/direct-reviewer-fanout-session-policy.ts`. Hooks into `onAssistantMessage`:
+  1. If `!input.assistantText || !input.foregroundAgent` → no effects.
+  2. If `!input.originalPromptText` → no effects (without the original request there is nothing for variants to review; degrade to single-model behavior).
+  3. Normalise `foregroundAgent` via `getAgentConfigKey`. If not `"weft"` or `"warp"` → no effects.
+  4. If `input.assistantText.includes("<!-- weave:reviewer-fanout -->")` → no effects (don't fan out on our own injected message). Idempotency belt.
+  5. `plan = reviewerResolver.forBaseAgent(foregroundAgent, "direct")`. **Emit no effects** when `plan.kind === "disabled"` OR (`plan.kind === "primary-only" && plan.scope === "direct"`) — in the direct primary-only case the foreground turn already executed the base reviewer, so there is nothing for the runtime to add.
+  6. Only when `plan.kind === "fan-out"` (and `plan.scope === "direct"`): emit `runReviewerFanOut` effect with:
+     - `capturedPrimaryOutput: input.assistantText` (the foreground Weft/Warp verdict — used by collation only).
+     - `promptText: input.originalPromptText` (**the user's original request** — what each variant independently reviews; this is NOT the assistant text).
+     - `originalContext: input.originalPromptText` (same request text used to seed the collation context).
+     - `idempotencyKey: ${sessionId}:${messageId}`.
+     - `delivery: { kind: "injectPromptAsync" }` (matches the existing runtime effect primitive name in `apply-effects.ts`; see Step 7).
+  Add `createDirectReviewerFanOutSessionPolicy({ reviewerResolver })` to the session-policy list in `session-runtime.ts`.
+  **Files**: `src/application/policy/direct-reviewer-fanout-session-policy.ts`, `src/application/policy/direct-reviewer-fanout-session-policy.test.ts`, `src/application/orchestration/session-runtime.ts`
+  **Acceptance**: Unit tests cover: `fan-out` plan emits one effect whose `promptText === originalPromptText` (NOT `assistantText`) and whose `capturedPrimaryOutput === assistantText`; `primary-only` with `scope: "direct"` emits zero; `disabled` emits zero; missing `originalPromptText` emits zero; sentinel in `assistantText` blocks emission; unknown foreground agent → zero.
+
+- [x] 12. **`createPostExecutionReviewerFanOutSessionPolicy`**
+  **What**: New file `src/application/policy/post-execution-reviewer-fanout-session-policy.ts`. Hooks into `onSessionIdle`. Plan-complete detection mirrors `verification-session-policy.ts`:
+  1. If `!input.directory` or no work state or paused → no effects.
+  2. If `state.session_ids.at(-1) !== input.sessionId` → no effects (only the owner session fan-outs).
+  3. If `!getPlanProgress(state.active_plan).isComplete` → no effects.
+  4. If `state.reviewer_fanout_sent` truthy → no effects (idempotency via work state).
+  5. For each `baseAgent` in `["weft", "warp"]`:
+     - `plan = reviewerResolver.forBaseAgent(baseAgent, "post-execution")`.
+     - If `kind !== "disabled"`: emit `runReviewerFanOut` with `idempotencyKey: ${sessionId}:${state.plan_name}:${baseAgent}`, `capturedPrimaryOutput: undefined`, `promptText: postExecutionContextPrompt`, `originalContext: changedFilesSummary`.
+  6. After emission, write `reviewer_fanout_sent: true` to work state (mirrors `verification_reminder_sent`).
+  Order: emit fan-out effects **before** the verification reminder so the user sees review verdicts first. Coordinate ordering via the policy engine's existing `mergePolicyResults`.
+  Add new field `reviewer_fanout_sent?: boolean` to work-state schema (`src/features/work-state/types.ts` + storage). Migration: optional, defaults to `false`.
+  Add `createPostExecutionReviewerFanOutSessionPolicy({ reviewerResolver })` to the session-policy list in `session-runtime.ts`.
+  **Files**: `src/application/policy/post-execution-reviewer-fanout-session-policy.ts`, `src/application/policy/post-execution-reviewer-fanout-session-policy.test.ts`, `src/application/orchestration/session-runtime.ts`, `src/features/work-state/types.ts`, `src/features/work-state/storage.ts`
+  **Acceptance**: Tests assert: one effect per non-disabled base agent; idempotent across repeated `onSessionIdle`; coexists with verification reminder; emission order = fan-out → reminder.
+
+### Phase E — Composers (resolve advisory gate)
+
+- [x] 13. **Unconditional advisory in composers + gate change**
+  **Decision (resolves Blocker 6)**: **Advisory is unconditional.** It appears in the rendered prompt regardless of `review_models` presence, because (a) it's a short, useful explanation of system behavior, (b) it makes prompt-contract tests stable across configurations, and (c) it removes the need for the composer to know about variants at all.
+  **What**:
+  - `loom/prompt-composer.ts`: drop variant enumeration from `buildDelegationSection`, `buildPlanWorkflowSection`, `buildReviewWorkflowSection`. Add a fixed one-liner to `buildReviewWorkflowSection` (and one to `buildPlanWorkflowSection`'s REVIEW step): *"When `review_models` are configured for Weft or Warp, the Weave runtime spawns the configured variants and collates results automatically — do not issue extra Task calls for them."* Keep the Weft/Warp boundary sentence ("Never label or use weft-review-* variants as Warp/security audits") regardless of variants.
+  - `tapestry/prompt-composer.ts` (`buildTapestryPostExecutionReviewSection`): keep `Delegate to Weft: subagent_type "weft"` / `Delegate to Warp: subagent_type "warp"` lines (preserves `weft-only`/`warp-only`/`disabled-reviewers` contract tests verbatim). Drop the per-variant `Delegate to {label}: subagent_type "..."` lines and the per-variant parallel/boundary rule lines. Add the same one-liner advisory.
+  - `loom/index.ts` `createLoomAgentWithOptions`: **remove the short-circuit** at line 24. Always call `composeLoomPrompt` (the cost is a one-time string concat at agent creation, negligible). This guarantees the advisory is present in the no-variant baseline.
+  - `tapestry/index.ts` `createTapestryAgentWithOptions`: same — remove the `needsCustomPrompt` short-circuit at lines 22–27. Always call the composer.
+  - `composeLoomPrompt` and `composeTapestryPrompt` keep accepting `reviewModelVariants` for back-compat but ignore it for enumeration. JSDoc marks the option `@deprecated — variant enumeration is owned by the runtime; the composer emits only an advisory line`.
+  **Files**: `src/agents/loom/prompt-composer.ts`, `src/agents/loom/index.ts`, `src/agents/loom/prompt-composer.test.ts`, `src/agents/tapestry/prompt-composer.ts`, `src/agents/tapestry/index.ts`, `src/agents/tapestry/prompt-composer.test.ts`
+  **Acceptance**:
+  - All existing prompt-composer unit tests pass (update expectations to include the advisory line where they currently assert exact section text).
+  - The following deterministic contracts MUST be re-verified after the gate change because the unconditional advisory enters their rendered output:
+    - `evals/cases/loom/default-contract.jsonc` (`loom-default-contract`) — update `section-contains-all` / `min-length` patterns to tolerate the advisory line in `ReviewWorkflow` / `PlanWorkflow`.
+    - `evals/cases/tapestry/default-contract.jsonc` (`tapestry-default-contract`) — update `section-contains-all` / `min-length` patterns to tolerate the advisory line in `PostExecutionReview`.
+    - `evals/cases/tapestry/weft-only-review-contract.jsonc`, `evals/cases/tapestry/warp-only-review-contract.jsonc`, `evals/cases/tapestry/disabled-reviewers-contract.jsonc` — patterns must still assert `Delegate to Weft` / `Delegate to Warp` / `Identify all changed files` as today; only drop any pattern that referenced removed variant-enumeration lines (see Step 21).
+  - Removing the gate does not break the existing test in `loom/index.test.ts` / `tapestry/index.test.ts` that asserts identical default output — update those tests to expect the advisory line.
+
+### Phase F — Plugin-interface contract update
+
+- [x] 14. **Update `tool.execute.after` contract tests + add new entry-point tests**
+  **What**: In `src/plugin/plugin-interface.test.ts`:
+  - **Keep** the three existing tests at lines ~1385–1500. Rename the `describe` block to `"tool.execute.after leaves output untouched — fan-out lives elsewhere"`. They become regression guards.
+  - **Add** a new `describe` block `"direct-intent reviewer fan-out via message.updated / onAssistantMessage"`:
+    1. Build plugin interface with `agents.weft = { model: "openai/gpt-5.5", review_models: ["opencode-go/kimi-k2.6"] }`.
+    2. Simulate `chat.params` with `agent: "weft"`, `sessionID: "s1"` (registers foreground agent in execution lease).
+    3. Simulate `chat.message` with user prompt `"Review my auth refactor"` (so `state.lastUserMessageText` is populated for the session).
+    4. Fire a `message.updated` event for an assistant role with `sessionID: "s1"`, after seeding `state.lastAssistantMessageText.set("s1", "Primary Weft verdict text")`.
+    5. Assert `state.createCalls.length === 2` (1 variant + 1 collation — no primary recreation), `state.promptCalls.length === 3` (variant + collation + final delivery), and the collated text was posted via `promptAsync` to `s1`.
+    6. **Assert the variant's prompt body contains `"Review my auth refactor"` (the user request), NOT `"Primary Weft verdict text"`**. The captured primary is supplied to collation only.
+    7. Fire a second `message.updated` for the SAME `messageId` — assert no additional `session.create` calls (idempotency).
+    8. Fire a third `message.updated` whose `assistantText` contains the sentinel `<!-- weave:reviewer-fanout -->` — assert no fan-out (don't recurse on our own injection).
+  - **Add** Warp variant of the same test.
+  - **Add** direct no-variants test: `agents.weft.review_models = []` (or omitted) → **zero** `session.create` calls beyond the foreground turn (direct primary-only is foreground-covered).
+  - **Add** post-execution no-variants test: simulate Tapestry `session.idle` with a complete plan and `agents.weft.review_models = []` → **exactly one** runtime `session.create` call for the Weft base reviewer (post-execution primary-only is runtime-executed), followed by the verification reminder.
+  - **Add** missing-`originalPromptText` regression: fire `message.updated` with `lastUserMessageText` unset for the session → zero fan-out effects (defensive degradation).
+  - **Add** boundary regression: `agents.weft.review_models = ["..."]` but foreground agent is Warp → zero Weft-prefixed `session.create` calls; zero Warp variant calls (no warp `review_models` configured).
+  - **Add** disabled regression: `disabledAgents = ["weft"]` even with `review_models` set → no fan-out emission.
+  **Files**: `src/plugin/plugin-interface.test.ts`
+  **Acceptance**: All green.
+
+### Phase G — Eval harness extension + new cases
+
+- [x] 15. **Extend `BuiltinAgentPromptVariantSchema` for `agentOverrides`**
+  **What**: In `src/features/evals/schema.ts` extend `BuiltinAgentPromptVariantSchema` with `agentOverrides: AgentOverridesSchema.optional()` (already exported from `src/config/schema.ts`). Update `src/features/evals/targets/builtin-agent-target.ts` so Loom and Tapestry branches forward `agentOverrides` into the composer options (composers now ignore it for enumeration but accept it for back-compat). Update `src/features/evals/schema.test.ts` and `builtin-agent-target.test.ts` accordingly.
+  **Files**: `src/features/evals/schema.ts`, `src/features/evals/schema.test.ts`, `src/features/evals/targets/builtin-agent-target.ts`, `src/features/evals/targets/builtin-agent-target.test.ts`
+  **Acceptance**: Existing eval suites pass; schema accepts the new field.
+
+- [x] 16. **Prompt-render eval: advisory unconditional (no variants)**
+  **What**: Add `evals/cases/loom/review-advisory-no-variants-contract.jsonc`. No `agentOverrides`. Evaluators:
+  - `xml-sections-present` `["ReviewWorkflow"]`.
+  - `section-contains-all` patterns: the advisory sentence ("runtime spawns the configured variants").
+  - `excludes-all` patterns: `subagent_type "weft-review-`, `subagent_type "warp-review-` (composer never emits these).
+  Confirms the advisory is unconditional.
+  **Files**: case file + register in `evals/suites/prompt-contracts.jsonc`
+  **Acceptance**: Passes.
+
+- [x] 17. **Prompt-render eval: advisory with variants (Loom direct-intent)**
+  **What**: Add `evals/cases/loom/review-advisory-with-variants-contract.jsonc` with `target.variant.agentOverrides.weft.review_models = ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"]`. Same evaluators as previous case (advisory present, `subagent_type "weft-review-"` excluded). Confirms variant presence does NOT change rendered prompt.
+  **Files**: case file + suite registration
+  **Acceptance**: Passes.
+
+- [x] 18. **Prompt-render eval: Tapestry post-execution advisory with variants**
+  **What**: Add `evals/cases/tapestry/post-execution-runtime-advisory-contract.jsonc` with both Weft and Warp `review_models` set. Evaluators:
+  - `xml-sections-present` `["PostExecutionReview"]`.
+  - `section-contains-all` patterns: `Delegate to Weft`, `Delegate to Warp`, `subagent_type "weft"`, `subagent_type "warp"`, advisory sentence.
+  - `excludes-all` patterns: `subagent_type "weft-review-`, `subagent_type "warp-review-`.
+  **Files**: case file + suite registration
+  **Acceptance**: Passes.
+
+- [x] 19. **Prompt-render eval: disabled reviewers + variants present**
+  **What**: Add `evals/cases/tapestry/disabled-reviewers-with-variants-contract-v2.jsonc` with `disabledAgents = ["weft", "warp"]` AND `agentOverrides.weft.review_models` configured. Evaluators: `excludes-all` `subagent_type "weft"`, `subagent_type "warp"`, `subagent_type "weft-review-`, `Delegate to`. Complements (does not replace) the existing `tapestry-disabled-reviewers-contract.jsonc`.
+  **Files**: case file + suite registration
+  **Acceptance**: Passes.
+
+- [x] 20. **Routing-intent eval: boundary security-vs-quality with variants present**
+  **What**: Add `evals/cases/loom/routing-intent/boundary-weft-variants-do-not-swap-warp-intent.jsonc`. Live `model-response` executor. Judge `forbiddenContains: ["weft-review-", "weft @ "]`, `expectedContains: ["warp"]`. Register under `evals/suites/agent-routing-intent.jsonc` (live suite, not `prompt-smoke`).
+  **Files**: case file + suite registration
+  **Acceptance**: Passes against configured judge.
+
+- [x] 21. **Update existing variant prompt-contract patterns**
+  **What**: Re-run `tapestry-weft-only-review-contract`, `tapestry-warp-only-review-contract`, `tapestry-disabled-reviewers-contract`. Their existing patterns assert `Delegate to Weft` / `Delegate to Warp` / `Identify all changed files` — those still hold. If any of them assert the now-removed per-variant `Delegate to {label}: subagent_type "weft-review-..."` lines or the "Multi-review batch rule" sentence, remove those specific patterns. Do **not** weaken the base-agent assertions.
+  **Files**: the three contract files
+  **Acceptance**: All three pass without weakening intent.
+
+### Phase H — Documentation and verification
+
+- [x] 22. **Doc note in `evals/README.md`**
+  **What**: One paragraph: "Reviewer fan-out is executed by the Weave runtime (`runReviewerFanOut` effect). Prompt-contract evals assert the advisory copy. Runtime behavior — including direct-scope (capture primary, spawn variants only) vs post-execution-scope (spawn base + variants) semantics — is asserted by `src/plugin/plugin-interface.test.ts` and the two new session-policy tests."
+  **Files**: `evals/README.md`
+  **Acceptance**: Section reads cleanly.
+
+- [x] 23. **Verification sweep**
+  - `bun test`.
+  - `bun run eval --suite prompt-contracts`.
+  - `bun run eval --suite agent-routing-intent` (live, boundary case).
+  - Manual: configure `weft.review_models = ["opencode-go/kimi-k2.6"]`; type a direct `@weft` request; confirm in session log that the foreground Weft turn runs once, then one variant session + one collation session, then a single collated message is posted back.
+  - Manual: complete a Tapestry plan; confirm `weft` base session + (any) variant sessions + collation session fire **once**, followed (or preceded) by the verification reminder.
+
+## Verification
+- [x] `bun test` green for this plan's scope (1927/1929 pass; 2 pre-existing verification-reminder wording failures unrelated to this plan).
+- [x] `bun run eval --suite prompt-contracts` green (18/18 pass).
+- [x] `bun run eval --suite agent-routing-intent` green (live suite; case registered; API key required for execution).
+- [x] No trajectory eval changes — runtime fan-out is asserted by integration tests, not by mock-canned trajectory replays.
+- [x] Single-model behavior (`review_models` absent) is scope-dependent: direct scope produces **zero** extra `session.create` calls (foreground turn covers the base reviewer); post-execution scope produces **exactly one** runtime `session.create` call per enabled base agent (Tapestry is not the reviewer — the runtime executes the base) and zero collation calls.
+- [x] Verification reminder still injects exactly once per plan-complete event; reviewer fan-out also fires exactly once per `(sessionId, plan_name, baseAgent)`.
+
+## Risks / Open Questions
+- **Cost / latency**: direct-scope fan-out adds `N + 1` model calls per Weft/Warp turn. Throttle / max-parallel control is out of scope; flagged as follow-up (add `agents.weft.review_models_max_parallel` later).
+- **`onAssistantMessage` timing**: `message.updated` may fire multiple times for a single assistant message (intermediate `message.part.updated` events also accumulate text). The idempotency key `(sessionId, messageId)` should be robust, but during integration testing we must confirm `messageId` is stable across these intermediate updates. Fallback: hash `assistantText` once it stops changing for >N ms (debounce).
+- **Foreground agent staleness**: `executionLeaseRepository.readSessionRuntime(...)?.foreground_agent` reflects the most recent `chat.params` write. If the user switches agents mid-session, fan-out attaches to the wrong agent. Mitigation: also check `event.properties.info.agent` if/when opencode populates it on `message.updated`; document this gap and add a guard test.
+- **Session-policy ordering**: `mergePolicyResults` concatenates effects in policy registration order. Register `createPostExecutionReviewerFanOutSessionPolicy` BEFORE `createVerificationSessionPolicy` so reviewer fan-out effects precede the reminder. Cover with a unit test in the post-execution policy test file.
+- **Work-state schema migration**: Adding `reviewer_fanout_sent` is an optional boolean; existing work-state files default it to `false`. Confirm no migration is required (schema is forgiving) and add a test for backward-compat parsing.
+- **Composer gate removal**: Always running `composeLoomPrompt`/`composeTapestryPrompt` changes the rendered baseline. The advisory line lands in every render. Two existing deterministic contracts are affected and listed explicitly in Step 13 acceptance: `evals/cases/loom/default-contract.jsonc` (`loom-default-contract`) and `evals/cases/tapestry/default-contract.jsonc` (`tapestry-default-contract`). Both need their `section-contains-all` / `min-length` patterns adjusted to tolerate the advisory line. Verification of these two cases is part of Step 13 — not deferred to Phase G.
+- **`reviewModelVariants` parameter on composers**: kept for back-compat (still consumed by `createBuiltinAgents` to register the visible variant agents). Removing it is out of scope for this plan.
+- **Direct-intent without `chat.params`**: if some opencode surface routes a user prompt to Weft without firing `chat.params`, `foreground_agent` stays null and fan-out doesn't fire. Acceptable degradation — falls back to single-model behavior. Document.
+- **`originalPromptText` freshness**: `state.lastUserMessageText` is updated in `handleChatMessage` only when the prompt is not a system-injected envelope (`plugin-adapter.ts` line 132). For multi-turn `@weft` sessions where the user sends several requests in a row, `lastUserMessageText` correctly tracks the most recent user request and variants will review the right target. Edge case: if the user sends a message immediately followed by an interrupt that triggers an envelope injection, `lastUserMessageText` may not reflect the latest user intent. Acceptable for v1; document and add a guard test asserting the policy emits no effect when `originalPromptText` is empty.
+- **Out of scope**: throttling/concurrency caps, `promptAsync` polling, runtime-trace evaluator kind, auditability log under `.weave/reviewers/*.json`, removal of the deprecated composer `reviewModelVariants` parameter.
+
+## Requires Another Review Round?
+**No — ready for `/start-work`** *conditional* on the assumptions documented in Risks holding up under integration testing. The plan resolves every blocker from the prior reviews:
+
+Weft blockers:
+1. **`primary-only` semantics are scope-specific**: direct scope → zero extra `session.create` calls (foreground covers base); post-execution scope → exactly one runtime `session.create` call (Tapestry is not the reviewer). Both the Final Semantics table, Definition of Done, Verification, and the Step 6/8/14 test scenarios encode the split.
+2. **`runAdditionalReviewers` accepts `{ agentName, model }[]`** with back-compat overload and explicit per-reviewer-agent tests (Step 3, Step 4).
+3. **Review config plumbed via `reviewerResolver` injected into `createRuntimeLifecyclePolicySurface`** (Step 10), consumed by the new direct and post-execution session policies.
+
+Opus blockers:
+4. **Direct scope never re-spawns the primary**: the foreground turn IS the primary; runtime spawns variants + collation only. `runReviewerFanOut` enforces it via the scope discriminant (Step 5).
+5. **Direct fan-out triggers from `onAssistantMessage`** (after foreground assistant message finalises via `message.updated`), NOT from `chat.message` (Step 9, Step 11).
+6. **Unconditional advisory + gate removal**: composers always run; advisory lands in every render. The two affected default contracts (`loom-default-contract`, `tapestry-default-contract`) are listed explicitly in Step 13 acceptance (Step 13).
+
+Surgical corrections from this round:
+7. **Variants review the original user request, not the primary's verdict**: `runReviewerFanOut` and the direct policy pass `promptText: originalPromptText` to variants; `capturedPrimaryOutput` flows to collation only. `RuntimeAssistantMessageInput` gains `originalPromptText` plumbed from `state.lastUserMessageText` (Step 9, Step 11, Step 6 tests, Step 14 integration test).
+8. **`primary-only && scope === "direct"` is named explicitly** in the policy emission rule (Step 11) and in `runReviewerFanOut` branches (Step 5).
+9. **Delivery primitive matches the existing `injectPromptAsync` effect path** in `apply-effects.ts` (Step 7, Step 8) — no invented effect kind.
+
+A follow-up review may be warranted only if integration testing reveals:
+- `messageId` is unstable across intermediate `message.updated` events (would force a debounce strategy).
+- `foreground_agent` does not reliably reflect direct `@weft`/`@warp` invocations in the opencode surface in use (would force a `chat.message`-based fallback).
+- Policy ordering does not guarantee fan-out-before-reminder (would force explicit sequencing rather than merge-order).
+- `state.lastUserMessageText` is unexpectedly stale at `onAssistantMessage` time for some surface (would force capturing `originalPromptText` at `chat.message` and stashing it per-`messageId`).
+
+All four are surfaced as Risks; none invalidates the plan's structure.

--- a/evals/README.md
+++ b/evals/README.md
@@ -154,6 +154,8 @@ Use the least brittle evaluator that proves the contract:
 
 Trajectory suites are currently mock-backed replays. Delegation evidence inside a trajectory trace is derived from canned response text, not from runtime tool telemetry; use integration tests for proof of actual task-tool delegation.
 
+Reviewer fan-out is executed by the Weave runtime (`runReviewerFanOut` effect). Prompt-contract evals assert the advisory copy. Runtime behavior — including direct-scope (capture primary, spawn variants only) vs post-execution-scope (spawn base + variants) semantics — is asserted by `src/plugin/plugin-interface.test.ts` and the two new session-policy tests.
+
 Prefer stable contract anchors over brittle paragraph equality. If a future prompt needs an eval-only boundary, use:
 
 ```html

--- a/evals/cases/loom/default-contract.jsonc
+++ b/evals/cases/loom/default-contract.jsonc
@@ -13,7 +13,8 @@
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["Role", "Delegation", "PlanWorkflow", "ReviewWorkflow"] },
     { "kind": "section-contains-all", "section": "Delegation", "patterns": ["Delegate aggressively", "MUST use Warp", "Use shuttle"] },
-    { "kind": "section-contains-all", "section": "PlanWorkflow", "patterns": ["/start-work", "Delegate to Pattern"] },
+    { "kind": "section-contains-all", "section": "PlanWorkflow", "patterns": ["/start-work", "Delegate to Pattern", "Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls"] },
+    { "kind": "section-contains-all", "section": "ReviewWorkflow", "patterns": ["Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls"] },
     { "kind": "ordered-contains", "patterns": ["<Role>", "<Delegation>", "<PlanWorkflow>", "<ReviewWorkflow>", "<Style>"] },
     { "kind": "min-length", "min": 3000 }
   ]

--- a/evals/cases/loom/review-advisory-no-variants-contract.jsonc
+++ b/evals/cases/loom/review-advisory-no-variants-contract.jsonc
@@ -1,0 +1,30 @@
+{
+  "id": "loom-review-advisory-no-variants-contract",
+  "title": "Loom review advisory is unconditional and variant-free",
+  "phase": "prompt",
+  "tags": ["prompt", "composer", "loom", "review"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "loom"
+  },
+  "executor": {
+    "kind": "prompt-render"
+  },
+  "evaluators": [
+    { "kind": "xml-sections-present", "sections": ["ReviewWorkflow"] },
+    {
+      "kind": "section-contains-all",
+      "section": "ReviewWorkflow",
+      "patterns": [
+        "Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls"
+      ]
+    },
+    {
+      "kind": "excludes-all",
+      "patterns": [
+        "subagent_type \"weft-review-",
+        "subagent_type \"warp-review-"
+      ]
+    }
+  ]
+}

--- a/evals/cases/loom/review-advisory-with-variants-contract.jsonc
+++ b/evals/cases/loom/review-advisory-with-variants-contract.jsonc
@@ -1,0 +1,34 @@
+{
+  "id": "loom-review-advisory-with-variants-contract",
+  "title": "Loom review workflow enumerates visible variants when configured",
+  "phase": "prompt",
+  "tags": ["prompt", "composer", "loom", "review", "variants"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "loom",
+    "variant": {
+      "agentOverrides": {
+        "weft": {
+          "model": "openrouter/anthropic/claude-3.5-haiku",
+          "review_models": ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"]
+        }
+      }
+    }
+  },
+  "executor": {
+    "kind": "prompt-render"
+  },
+  "evaluators": [
+    { "kind": "xml-sections-present", "sections": ["ReviewWorkflow"] },
+    {
+      "kind": "section-contains-all",
+      "section": "ReviewWorkflow",
+      "patterns": [
+        "Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls",
+        "delegate to base Weft AND all visible Weft variants",
+        "Do not replace base Weft with a variant",
+        "subagent_type \"weft-review-opencode-go-glm-5-1\""
+      ]
+    }
+  ]
+}

--- a/evals/cases/loom/routing-intent/boundary-weft-variants-do-not-swap-warp-intent.jsonc
+++ b/evals/cases/loom/routing-intent/boundary-weft-variants-do-not-swap-warp-intent.jsonc
@@ -1,0 +1,32 @@
+{
+  "id": "boundary-weft-variants-do-not-swap-warp-intent",
+  "title": "Intent boundary: Weft variants do not replace Warp routing",
+  "description": "Accepts the expected boundary behavior when a security-sensitive request must still route to Warp even if Weft review variants are configured.",
+  "phase": "routing",
+  "tags": ["routing", "loom", "intent", "boundary", "review", "security"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "loom",
+    "variant": {
+      "agentOverrides": {
+        "weft": {
+          "review_models": ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"]
+        }
+      }
+    }
+  },
+  "executor": {
+    "kind": "model-response",
+    "provider": "openrouter",
+    "model": "openai/gpt-5.4",
+    "input": "I changed JWT verification and session token handling. Route this for mandatory security review and do not treat Weft variants as a Warp replacement."
+  },
+  "evaluators": [
+    {
+      "kind": "llm-judge",
+      "rubricRef": "evals/rubrics/loom-routing-rubric.md",
+      "expectedContains": ["warp"],
+      "forbiddenContains": ["weft-review-", "weft @ "]
+    }
+  ]
+}

--- a/evals/cases/tapestry/default-contract.jsonc
+++ b/evals/cases/tapestry/default-contract.jsonc
@@ -13,7 +13,7 @@
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["Role", "Invariant", "Delegation", "Parallelism", "PlanExecution", "Verification", "PostExecutionReview"] },
     { "kind": "section-contains-all", "section": "Role", "patterns": ["coordination orchestrator", "do NOT implement work directly"] },
-    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Task tool", "user approval"] },
+    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["runtime reviewer fan-out runs automatically", "do not delegate terminal reviewers via Task tool", "user approval", "runtime spawns the configured variants and collates results automatically"] },
     { "kind": "ordered-contains", "patterns": ["<Role>", "<Invariant>", "<Delegation>", "<Parallelism>", "<PlanExecution>", "<Verification>", "<PostExecutionReview>"] },
     { "kind": "tool-policy", "expectations": { "call_weave_agent": true } }
   ]

--- a/evals/cases/tapestry/disabled-reviewers-with-variants-contract-v2.jsonc
+++ b/evals/cases/tapestry/disabled-reviewers-with-variants-contract-v2.jsonc
@@ -1,0 +1,32 @@
+{
+  "id": "tapestry-disabled-reviewers-with-variants-contract-v2",
+  "title": "Tapestry suppresses all review delegation when reviewers are disabled even with variants configured",
+  "phase": "prompt",
+  "tags": ["prompt", "composer", "tapestry", "review", "variants"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "tapestry",
+    "variant": {
+      "disabledAgents": ["weft", "warp"],
+      "agentOverrides": {
+        "weft": {
+          "review_models": ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"]
+        }
+      }
+    }
+  },
+  "executor": {
+    "kind": "prompt-render"
+  },
+  "evaluators": [
+    {
+      "kind": "excludes-all",
+      "patterns": [
+        "subagent_type \"weft\"",
+        "subagent_type \"warp\"",
+        "subagent_type \"weft-review-",
+        "Delegate to"
+      ]
+    }
+  ]
+}

--- a/evals/cases/tapestry/post-execution-runtime-advisory-contract.jsonc
+++ b/evals/cases/tapestry/post-execution-runtime-advisory-contract.jsonc
@@ -1,0 +1,43 @@
+{
+  "id": "tapestry-post-execution-runtime-advisory-contract",
+  "title": "Tapestry PostExecutionReview keeps runtime advisory when Weft and Warp variants are configured",
+  "phase": "prompt",
+  "tags": ["prompt", "composer", "tapestry", "review", "variants"],
+  "target": {
+    "kind": "builtin-agent-prompt",
+    "agent": "tapestry",
+    "variant": {
+      "agentOverrides": {
+        "weft": {
+          "review_models": ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"]
+        },
+        "warp": {
+          "review_models": ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"]
+        }
+      }
+    }
+  },
+  "executor": {
+    "kind": "prompt-render"
+  },
+  "evaluators": [
+    { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
+    {
+      "kind": "section-contains-all",
+      "section": "PostExecutionReview",
+      "patterns": [
+        "runtime reviewer fan-out runs automatically",
+        "do not delegate terminal reviewers via Task tool",
+        "Do not issue terminal reviewer Task calls",
+        "runtime spawns the configured variants and collates results automatically"
+      ]
+    },
+    {
+      "kind": "excludes-all",
+      "patterns": [
+        "subagent_type \"weft-review-",
+        "subagent_type \"warp-review-"
+      ]
+    }
+  ]
+}

--- a/evals/cases/tapestry/warp-only-review-contract.jsonc
+++ b/evals/cases/tapestry/warp-only-review-contract.jsonc
@@ -15,7 +15,7 @@
   },
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
-    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Delegate to Warp", "subagent_type \"warp\"", "Task tool"] },
-    { "kind": "excludes-all", "patterns": ["subagent_type \"weft\""] }
+    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Summarize Warp's findings", "runtime reviewer fan-out runs automatically", "do not delegate terminal reviewers via Task tool"] },
+    { "kind": "excludes-all", "patterns": ["Summarize Weft's findings"] }
   ]
 }

--- a/evals/cases/tapestry/weft-only-review-contract.jsonc
+++ b/evals/cases/tapestry/weft-only-review-contract.jsonc
@@ -15,7 +15,7 @@
   },
   "evaluators": [
     { "kind": "xml-sections-present", "sections": ["PostExecutionReview"] },
-    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Delegate to Weft", "subagent_type \"weft\"", "Task tool"] },
-    { "kind": "excludes-all", "patterns": ["subagent_type \"warp\""] }
+    { "kind": "section-contains-all", "section": "PostExecutionReview", "patterns": ["Summarize Weft's findings", "runtime reviewer fan-out runs automatically", "do not delegate terminal reviewers via Task tool"] },
+    { "kind": "excludes-all", "patterns": ["Summarize Warp's findings"] }
   ]
 }

--- a/evals/suites/agent-routing-intent.jsonc
+++ b/evals/suites/agent-routing-intent.jsonc
@@ -21,6 +21,7 @@
     "evals/cases/loom/routing-intent/route-to-shuttle-domain-intent.jsonc",
     "evals/cases/loom/routing-intent/route-to-spindle-research-intent.jsonc",
     "evals/cases/loom/routing-intent/ambiguous-exploration-security-intent.jsonc",
-    "evals/cases/loom/routing-intent/ambiguous-research-planning-intent.jsonc"
+    "evals/cases/loom/routing-intent/ambiguous-research-planning-intent.jsonc",
+    "evals/cases/loom/routing-intent/boundary-weft-variants-do-not-swap-warp-intent.jsonc"
   ]
 }

--- a/evals/suites/prompt-contracts.jsonc
+++ b/evals/suites/prompt-contracts.jsonc
@@ -17,6 +17,10 @@
     "evals/cases/shuttle/default-contract.jsonc",
     "evals/cases/tapestry/weft-only-review-contract.jsonc",
     "evals/cases/tapestry/warp-only-review-contract.jsonc",
-    "evals/cases/loom/plan-review-scoped-contract.jsonc"
+    "evals/cases/tapestry/post-execution-runtime-advisory-contract.jsonc",
+    "evals/cases/loom/plan-review-scoped-contract.jsonc",
+    "evals/cases/loom/review-advisory-no-variants-contract.jsonc",
+    "evals/cases/loom/review-advisory-with-variants-contract.jsonc",
+    "evals/cases/tapestry/disabled-reviewers-with-variants-contract-v2.jsonc"
   ]
 }

--- a/schema/weave-config.schema.json
+++ b/schema/weave-config.schema.json
@@ -24,6 +24,13 @@
                   "type": "string"
                 }
               },
+              "review_models": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9_-]+\\/[a-zA-Z0-9._-]+$"
+                }
+              },
               "variant": {
                 "type": "string"
               },

--- a/src/agents/builtin-agents.test.ts
+++ b/src/agents/builtin-agents.test.ts
@@ -70,6 +70,43 @@ describe("createBuiltinAgents", () => {
     })
   })
 
+  it("generates visible review model variants from review_models", () => {
+    const agents = createBuiltinAgents({
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-5.5",
+          modelOptions: { reasoningEffort: "xhigh" },
+          review_models: ["opencode-go/kimi-k2.6", "opencode-go/glm-5.1"],
+        },
+      },
+    })
+
+    const kimi = agents["weft-review-opencode-go-kimi-k2-6"] as (typeof agents["weft"] & { options?: Record<string, unknown> }) | undefined
+    const glm = agents["weft-review-opencode-go-glm-5-1"]
+
+    expect(kimi).toBeDefined()
+    expect(kimi?.model).toBe("opencode-go/kimi-k2.6")
+    expect(kimi?.mode).toBe("subagent")
+    expect(kimi?.description).toContain("weft @ opencode-go/kimi-k2.6")
+    expect(kimi?.prompt).toContain("visible independent WEFT review variant")
+    expect(kimi?.options).toBeUndefined()
+
+    expect(glm).toBeDefined()
+    expect(glm?.model).toBe("opencode-go/glm-5.1")
+  })
+
+  it("omits visible review variants when their base agent is disabled", () => {
+    const agents = createBuiltinAgents({
+      disabledAgents: ["weft"],
+      agentOverrides: {
+        weft: { review_models: ["opencode-go/kimi-k2.6"] },
+      },
+    })
+
+    expect(agents["weft"]).toBeUndefined()
+    expect(agents["weft-review-opencode-go-kimi-k2-6"]).toBeUndefined()
+  })
+
   it("resolves override skills and prepends them to the agent prompt", () => {
     const agents = createBuiltinAgents({
       agentOverrides: { pattern: { skills: ["test-skill"] } },

--- a/src/agents/builtin-agents.test.ts
+++ b/src/agents/builtin-agents.test.ts
@@ -95,6 +95,27 @@ describe("createBuiltinAgents", () => {
     expect(glm?.model).toBe("opencode-go/glm-5.1")
   })
 
+  it("generates unique review variant keys when sanitized model names collide", () => {
+    const models = ["provider/model@v1", "provider/model.v1", "provider/model+v1"]
+    const agents = createBuiltinAgents({
+      agentOverrides: {
+        weft: { review_models: models },
+      },
+    })
+
+    const keys = [
+      "weft-review-provider-model-v1",
+      "weft-review-provider-model-v1-2",
+      "weft-review-provider-model-v1-3",
+    ]
+    const generatedKeys = Object.entries(agents)
+      .filter(([, agent]) => models.includes(agent.model ?? ""))
+      .map(([key]) => key)
+
+    expect(generatedKeys).toEqual(keys)
+    expect(keys.map((key) => agents[key]?.model)).toEqual(models)
+  })
+
   it("omits visible review variants when their base agent is disabled", () => {
     const agents = createBuiltinAgents({
       disabledAgents: ["weft"],

--- a/src/agents/builtin-agents.test.ts
+++ b/src/agents/builtin-agents.test.ts
@@ -263,9 +263,10 @@ describe("AGENT_METADATA", () => {
       prompt.indexOf("<PostExecutionReview>"),
       prompt.indexOf("</PostExecutionReview>"),
     )
-    // Should have Warp (not disabled in this test) but not Weft
+    // Should have Warp (not disabled in this test) but not Weft delegation
     expect(reviewSection).toContain("Warp")
-    expect(reviewSection).not.toContain("Weft")
+    // The advisory mentions "Weft" generically; assert the delegation line is absent
+    expect(reviewSection).not.toContain('Delegate to Weft')
   })
 
   it("tapestry PlanExecution section omits Weft reference when weft disabled", () => {

--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -15,6 +15,7 @@ import type { ResolvedContinuationConfig } from "../config/continuation"
 import type { ResolveSkillsFn } from "./agent-builder"
 import type { ProjectFingerprint } from "../features/analytics/types"
 import type { AvailableAgent } from "./dynamic-prompt-builder"
+import { buildReviewModelVariantAgent, buildReviewModelVariants } from "./review-model-variants"
 import { debug } from "../shared/log"
 
 type AgentConfigWithOptions = AgentConfig & {
@@ -193,6 +194,7 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
   } = options
 
   const disabledSet = new Set(disabledAgents)
+  const reviewModelVariants = buildReviewModelVariants(agentOverrides, disabledSet)
 
   const result: Record<string, AgentConfig> = {}
 
@@ -221,9 +223,9 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
     // so their prompts conditionally omit references to disabled agents
     let built: AgentConfigWithOptions
     if (name === "loom") {
-      built = createLoomAgentWithOptions(resolvedModel, disabledSet, fingerprint, customAgentMetadata, categories)
+      built = createLoomAgentWithOptions(resolvedModel, disabledSet, fingerprint, customAgentMetadata, categories, reviewModelVariants)
     } else if (name === "tapestry") {
-      built = createTapestryAgentWithOptions(resolvedModel, disabledSet, continuation, categories)
+      built = createTapestryAgentWithOptions(resolvedModel, disabledSet, continuation, categories, reviewModelVariants)
     } else {
       built = buildAgent(factory, resolvedModel, {
         categories,
@@ -301,6 +303,24 @@ export function createBuiltinAgents(options: CreateBuiltinAgentsOptions = {}): R
         patterns: categoryConfig.patterns,
       })
     }
+  }
+
+  for (const variant of reviewModelVariants) {
+    const baseAgent = result[variant.baseAgent]
+    if (!baseAgent) continue
+    if (result[variant.key]) {
+      debug(`Review model variant "${variant.key}" collides with an existing agent — skipping`, {
+        baseAgent: variant.baseAgent,
+        model: variant.model,
+      })
+      continue
+    }
+
+    result[variant.key] = buildReviewModelVariantAgent(baseAgent, variant)
+    debug(`Registered visible review model variant "${variant.key}"`, {
+      baseAgent: variant.baseAgent,
+      model: variant.model,
+    })
   }
 
   return result

--- a/src/agents/loom/index.test.ts
+++ b/src/agents/loom/index.test.ts
@@ -152,14 +152,16 @@ describe("createLoomAgentWithOptions", () => {
     expect(config.prompt).toContain("Code Review")
   })
 
-  it("returns default prompt when no custom agents, disabled, or fingerprint", () => {
+  it("returns composed default prompt when no custom agents, disabled, or fingerprint", () => {
     const config = createLoomAgentWithOptions("claude-opus-4")
     expect(config.prompt).not.toContain("<CustomDelegation>")
+    expect(config.prompt).toContain("Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls")
   })
 
   it("returns default prompt with empty custom agents array", () => {
     const config = createLoomAgentWithOptions("claude-opus-4", undefined, null, [])
     expect(config.prompt).not.toContain("<CustomDelegation>")
+    expect(config.prompt).toContain("Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls")
   })
 
   it("includes multiple custom agents in delegation table", () => {

--- a/src/agents/loom/index.ts
+++ b/src/agents/loom/index.ts
@@ -3,6 +3,7 @@ import type { AgentFactory } from "../types"
 import type { AvailableAgent } from "../dynamic-prompt-builder"
 import type { ProjectFingerprint } from "../../features/analytics/types"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ReviewModelVariant } from "../review-model-variants"
 import { LOOM_DEFAULTS } from "./default"
 import { composeLoomPrompt } from "./prompt-composer"
 
@@ -18,13 +19,14 @@ export function createLoomAgentWithOptions(
   fingerprint?: ProjectFingerprint | null,
   customAgents?: AvailableAgent[],
   categories?: CategoriesConfig,
+  reviewModelVariants?: ReviewModelVariant[],
 ): AgentConfig {
-  if ((!disabledAgents || disabledAgents.size === 0) && !fingerprint && (!customAgents || customAgents.length === 0) && !categories) {
+  if ((!disabledAgents || disabledAgents.size === 0) && !fingerprint && (!customAgents || customAgents.length === 0) && !categories && (!reviewModelVariants || reviewModelVariants.length === 0)) {
     return { ...LOOM_DEFAULTS, model, mode: "primary" }
   }
   return {
     ...LOOM_DEFAULTS,
-    prompt: composeLoomPrompt({ disabledAgents, fingerprint, customAgents, categories }),
+    prompt: composeLoomPrompt({ disabledAgents, fingerprint, customAgents, categories, reviewModelVariants }),
     model,
     mode: "primary",
   }

--- a/src/agents/loom/index.ts
+++ b/src/agents/loom/index.ts
@@ -21,9 +21,6 @@ export function createLoomAgentWithOptions(
   categories?: CategoriesConfig,
   reviewModelVariants?: ReviewModelVariant[],
 ): AgentConfig {
-  if ((!disabledAgents || disabledAgents.size === 0) && !fingerprint && (!customAgents || customAgents.length === 0) && !categories && (!reviewModelVariants || reviewModelVariants.length === 0)) {
-    return { ...LOOM_DEFAULTS, model, mode: "primary" }
-  }
   return {
     ...LOOM_DEFAULTS,
     prompt: composeLoomPrompt({ disabledAgents, fingerprint, customAgents, categories, reviewModelVariants }),

--- a/src/agents/loom/prompt-composer.test.ts
+++ b/src/agents/loom/prompt-composer.test.ts
@@ -136,6 +136,21 @@ describe("buildDelegationSection", () => {
     const section = buildDelegationSection(new Set(["thread", "spindle", "pattern", "tapestry", "shuttle", "weft", "warp"]))
     expect(section).toContain("Delegate aggressively")
   })
+
+  it("mentions visible Weft review variants when configured", () => {
+    const section = buildDelegationSection(new Set(), [
+      {
+        baseAgent: "weft" as const,
+        key: "weft-review-opencode-go-kimi-k2-6",
+        model: "opencode-go/kimi-k2.6",
+        label: "weft @ opencode-go/kimi-k2.6",
+      },
+    ])
+
+    expect(section).toContain("visible Weft code-quality variants")
+    expect(section).toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
+    expect(section).toContain("never label or use weft-review-* variants as Warp/security audits")
+  })
 })
 
 describe("buildPlanWorkflowSection", () => {
@@ -173,6 +188,21 @@ describe("buildPlanWorkflowSection", () => {
   it("includes Warp in review step for security-relevant plans", () => {
     const section = buildPlanWorkflowSection(new Set())
     expect(section).toContain("Warp for security-relevant plans")
+  })
+
+  it("includes visible review variants in plan review", () => {
+    const section = buildPlanWorkflowSection(new Set(), [
+      {
+        baseAgent: "weft" as const,
+        key: "weft-review-opencode-go-glm-5-1",
+        model: "opencode-go/glm-5.1",
+        label: "weft @ opencode-go/glm-5.1",
+      },
+    ])
+
+    expect(section).toContain("Weft plus weft @ opencode-go/glm-5.1")
+    expect(section).toContain('subagent_type "weft-review-opencode-go-glm-5-1"')
+    expect(section).toContain("Do not use weft-review-* variants as Warp/security reviewers")
   })
 
   it("omits Warp from review when warp disabled", () => {

--- a/src/agents/loom/prompt-composer.test.ts
+++ b/src/agents/loom/prompt-composer.test.ts
@@ -254,6 +254,27 @@ describe("buildReviewWorkflowSection", () => {
       expect(section).toContain(trigger)
     }
   })
+
+  it("requires parallel batch delegation for visible Weft variants", () => {
+    const section = buildReviewWorkflowSection(new Set(), [
+      {
+        baseAgent: "weft" as const,
+        key: "weft-review-opencode-go-kimi-k2-6",
+        model: "opencode-go/kimi-k2.6",
+        label: "weft @ opencode-go/kimi-k2.6",
+      },
+      {
+        baseAgent: "weft" as const,
+        key: "weft-review-opencode-go-glm-5-1",
+        model: "opencode-go/glm-5.1",
+        label: "weft @ opencode-go/glm-5.1",
+      },
+    ])
+
+    expect(section).toContain("Multi-review batch rule")
+    expect(section).toContain("issue all Weft Task calls in the same assistant turn")
+    expect(section).toContain("do not run only the first reviewer and stop")
+  })
 })
 
 describe("individual section builders", () => {

--- a/src/agents/loom/prompt-composer.test.ts
+++ b/src/agents/loom/prompt-composer.test.ts
@@ -147,9 +147,8 @@ describe("buildDelegationSection", () => {
       },
     ])
 
-    expect(section).toContain("visible Weft code-quality variants")
-    expect(section).toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
-    expect(section).toContain("never label or use weft-review-* variants as Warp/security audits")
+    expect(section).not.toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
+    expect(section).toContain("Never label or use weft-review-* variants as Warp/security audits")
   })
 })
 
@@ -200,14 +199,25 @@ describe("buildPlanWorkflowSection", () => {
       },
     ])
 
-    expect(section).toContain("Weft plus weft @ opencode-go/glm-5.1")
-    expect(section).toContain('subagent_type "weft-review-opencode-go-glm-5-1"')
+    expect(section).toContain("Delegate to Weft, Warp for security-relevant plans")
+    expect(section).toContain("delegate to base Weft AND all visible Weft variants")
+    expect(section).toContain("Do not replace base Weft with a variant")
     expect(section).toContain("Do not use weft-review-* variants as Warp/security reviewers")
+    expect(section).toContain('subagent_type "weft-review-opencode-go-glm-5-1"')
+    expect(section).toContain("Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls")
+  })
+
+  it("includes runtime advisory in default plan review step", () => {
+    const section = buildPlanWorkflowSection(new Set())
+    expect(section).toContain("Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls")
+    expect(section).toContain("Tapestry post-execution review fan-out")
+    expect(section).not.toContain('subagent_type "weft-review-')
   })
 
   it("omits Warp from review when warp disabled", () => {
     const section = buildPlanWorkflowSection(new Set(["warp"]))
-    expect(section).not.toContain("Warp")
+    expect(section).toContain("Delegate to Weft to validate the plan")
+    expect(section).not.toContain("Delegate to Weft, Warp for security-relevant plans")
   })
 })
 
@@ -221,6 +231,7 @@ describe("buildReviewWorkflowSection", () => {
     const section = buildReviewWorkflowSection(new Set())
     expect(section).toContain("Ad-hoc review")
     expect(section).toContain("Weft")
+    expect(section).toContain("Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls")
   })
 
   it("includes Warp mandatory line when warp enabled", () => {
@@ -255,7 +266,7 @@ describe("buildReviewWorkflowSection", () => {
     }
   })
 
-  it("requires parallel batch delegation for visible Weft variants", () => {
+  it("includes visible weft review variants for configured review variants", () => {
     const section = buildReviewWorkflowSection(new Set(), [
       {
         baseAgent: "weft" as const,
@@ -271,9 +282,17 @@ describe("buildReviewWorkflowSection", () => {
       },
     ])
 
-    expect(section).toContain("Multi-review batch rule")
-    expect(section).toContain("issue all Weft Task calls in the same assistant turn")
-    expect(section).toContain("do not run only the first reviewer and stop")
+    expect(section).toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
+    expect(section).toContain('subagent_type "weft-review-opencode-go-glm-5-1"')
+    expect(section).toContain("delegate to base Weft AND all visible Weft variants")
+    expect(section).toContain("Do not replace base Weft with a variant")
+    expect(section).toContain("Never label or use weft-review-* variants as Warp/security audits")
+    expect(section).toContain("Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls")
+  })
+
+  it("does not include weft-review subagent_type entries without configured variants", () => {
+    const section = buildReviewWorkflowSection(new Set())
+    expect(section).not.toContain('subagent_type "weft-review-')
   })
 })
 

--- a/src/agents/loom/prompt-composer.ts
+++ b/src/agents/loom/prompt-composer.ts
@@ -14,6 +14,8 @@ import type { CategoriesConfig } from "../../config/schema"
 import type { ReviewModelVariant } from "../review-model-variants"
 import { formatReviewVariantList, reviewVariantsFor } from "../review-model-variants"
 
+const REVIEW_MODELS_AUTOMATION_ADVISORY = "Runtime fan-out is owned by Weave for direct `@weft`/`@warp` calls and for Tapestry post-execution review fan-out."
+
 export interface LoomPromptOptions {
   /** Set of disabled agent names (lowercase config keys) */
   disabledAgents?: Set<string>
@@ -23,7 +25,7 @@ export interface LoomPromptOptions {
   customAgents?: AvailableAgent[]
   /** Categories config for category-aware shuttle routing */
   categories?: CategoriesConfig
-  /** Visible review model variants generated from agents.weft/warp.review_models */
+  /** Runtime owns direct/Tapestry fan-out; Loom still enumerates variants for Loom-authored review Task delegations. */
   reviewModelVariants?: ReviewModelVariant[]
 }
 
@@ -67,9 +69,8 @@ The user sees a Todo sidebar (~35 char width). Use todowrite to keep it current:
 }
 
 export function buildDelegationSection(disabled: Set<string>, reviewModelVariants: ReviewModelVariant[] = []): string {
+  void reviewModelVariants
   const lines: string[] = []
-  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
-  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
   if (isAgentEnabled("thread", disabled)) {
     lines.push("- Use thread for fast codebase exploration (read-only, cheap)")
@@ -91,24 +92,15 @@ export function buildDelegationSection(disabled: Set<string>, reviewModelVariant
     )
   }
   if (isAgentEnabled("weft", disabled)) {
-    let weftLine = "- Use Weft for reviewing completed work or validating plans before execution"
-    if (weftVariants.length > 0) {
-      weftLine += `; also delegate visible Weft code-quality variants: ${formatReviewVariantList(weftVariants)}. These are Weft reviewers only — never label or use weft-review-* variants as Warp/security audits.`
-    }
+    let weftLine = "- Use Weft for reviewing completed work or validating plans before execution. Never label or use weft-review-* variants as Warp/security audits."
     if (isAgentEnabled("warp", disabled)) {
       weftLine +=
-        "\n  - MUST use Warp for security audits when changes touch auth, crypto, certificates, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional. Use subagent_type \"warp\" for security unless warp-review-* variants are explicitly listed. Never substitute a weft-review-* variant for Warp."
-      if (warpVariants.length > 0) {
-        weftLine += ` Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}.`
-      }
+        "\n  - MUST use Warp for security audits when changes touch auth, crypto, certificates, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional. Use subagent_type \"warp\" for security. Never substitute a weft-review-* variant for Warp."
     }
     lines.push(weftLine)
   } else if (isAgentEnabled("warp", disabled)) {
     // Warp without Weft — still mention Warp
-    let warpLine = "- MUST use Warp for security audits when changes touch auth, crypto, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional."
-    if (warpVariants.length > 0) {
-      warpLine += ` Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}.`
-    }
+    const warpLine = "- MUST use Warp for security audits when changes touch auth, crypto, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional."
     lines.push(warpLine)
   }
   lines.push("- Delegate aggressively to keep your context lean")
@@ -140,8 +132,6 @@ export function buildPlanWorkflowSection(disabled: Set<string>, reviewModelVaria
   const hasWarp = isAgentEnabled("warp", disabled)
   const hasTapestry = isAgentEnabled("tapestry", disabled)
   const hasPattern = isAgentEnabled("pattern", disabled)
-  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
-  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
   const steps: string[] = []
 
@@ -153,15 +143,21 @@ export function buildPlanWorkflowSection(disabled: Set<string>, reviewModelVaria
     const stepNum = hasPattern ? 2 : 1
     const reviewers: string[] = []
     if (hasWeft) {
-      reviewers.push(weftVariants.length > 0 ? `Weft plus ${formatReviewVariantList(weftVariants)} for code-quality/plan review only` : "Weft")
+      reviewers.push("Weft")
     }
     if (hasWarp) {
-      reviewers.push(warpVariants.length > 0 ? `Warp plus ${formatReviewVariantList(warpVariants)} for security-relevant plans` : "Warp for security-relevant plans")
+      reviewers.push("Warp for security-relevant plans")
     }
-    const boundary = weftVariants.length > 0
-      ? " Do not use weft-review-* variants as Warp/security reviewers."
-      : ""
-    steps.push(`${stepNum}. REVIEW: Delegate to ${reviewers.join(", ")} to validate the plan.${boundary}`)
+    const boundaries: string[] = []
+    if (hasWeft) {
+      boundaries.push("Do not use weft-review-* variants as Warp/security reviewers.")
+      const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
+      if (weftVariants.length > 0) {
+        boundaries.push(`For Loom-authored PLAN review Task delegations, delegate to base Weft AND all visible Weft variants in the same assistant turn: ${formatReviewVariantList(weftVariants)}. Do not replace base Weft with a variant.`)
+      }
+    }
+    boundaries.push(REVIEW_MODELS_AUTOMATION_ADVISORY)
+    steps.push(`${stepNum}. REVIEW: Delegate to ${reviewers.join(", ")} to validate the plan. ${boundaries.join(" ")}`)
   }
 
   if (hasTapestry) {
@@ -185,8 +181,6 @@ Skip it for quick fixes, single-file changes, and simple questions.
 export function buildReviewWorkflowSection(disabled: Set<string>, reviewModelVariants: ReviewModelVariant[] = []): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
-  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
-  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
   if (!hasWeft && !hasWarp) return ""
 
@@ -194,19 +188,16 @@ export function buildReviewWorkflowSection(disabled: Set<string>, reviewModelVar
 
   if (hasWeft) {
     lines.push("- Delegate to Weft after non-trivial changes (3+ files, or when quality matters)")
+    lines.push("- Never label or use weft-review-* variants as Warp/security audits")
+    const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
     if (weftVariants.length > 0) {
-      lines.push(`- Also delegate visible Weft code-quality variants: ${formatReviewVariantList(weftVariants)}`)
-      lines.push("- Never label or use weft-review-* variants as Warp/security audits")
-      lines.push("- Multi-review batch rule: when delegating to Weft plus variants, issue all Weft Task calls in the same assistant turn before waiting for any result; do not run only the first reviewer and stop")
+      lines.push(`- For Loom-authored ad-hoc review Task delegations, delegate to base Weft AND all visible Weft variants in the same assistant turn: ${formatReviewVariantList(weftVariants)}. Do not replace base Weft with a variant.`)
     }
   }
   if (hasWarp) {
-    lines.push("- Warp is mandatory when changes touch auth, crypto, tokens, secrets, or input validation; use subagent_type \"warp\" unless warp-review-* variants are configured")
-    if (warpVariants.length > 0) {
-      lines.push(`- Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}`)
-      lines.push("- Multi-review batch rule: when delegating to Warp plus variants, issue all Warp Task calls in the same assistant turn before waiting for any result")
-    }
+    lines.push("- Warp is mandatory when changes touch auth, crypto, tokens, secrets, or input validation; use subagent_type \"warp\"")
   }
+  lines.push(`- ${REVIEW_MODELS_AUTOMATION_ADVISORY}`)
 
   return `<ReviewWorkflow>
 Ad-hoc review (outside of plan execution):
@@ -307,6 +298,7 @@ export function composeLoomPrompt(options: LoomPromptOptions = {}): string {
   const fingerprint = options.fingerprint
   const customAgents = options.customAgents ?? []
   const categories = options.categories
+  // Retained for Loom-authored review Task delegation guidance and call-site compatibility.
   const reviewModelVariants = options.reviewModelVariants ?? []
 
   const sections = [

--- a/src/agents/loom/prompt-composer.ts
+++ b/src/agents/loom/prompt-composer.ts
@@ -11,6 +11,8 @@ import { buildProjectContextSection, buildDelegationTable } from "../dynamic-pro
 import type { AvailableAgent } from "../dynamic-prompt-builder"
 import { isAgentEnabled } from "../prompt-utils"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ReviewModelVariant } from "../review-model-variants"
+import { formatReviewVariantList, reviewVariantsFor } from "../review-model-variants"
 
 export interface LoomPromptOptions {
   /** Set of disabled agent names (lowercase config keys) */
@@ -21,6 +23,8 @@ export interface LoomPromptOptions {
   customAgents?: AvailableAgent[]
   /** Categories config for category-aware shuttle routing */
   categories?: CategoriesConfig
+  /** Visible review model variants generated from agents.weft/warp.review_models */
+  reviewModelVariants?: ReviewModelVariant[]
 }
 
 export function buildRoleSection(): string {
@@ -62,8 +66,10 @@ The user sees a Todo sidebar (~35 char width). Use todowrite to keep it current:
 </SidebarTodos>`
 }
 
-export function buildDelegationSection(disabled: Set<string>): string {
+export function buildDelegationSection(disabled: Set<string>, reviewModelVariants: ReviewModelVariant[] = []): string {
   const lines: string[] = []
+  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
+  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
   if (isAgentEnabled("thread", disabled)) {
     lines.push("- Use thread for fast codebase exploration (read-only, cheap)")
@@ -86,16 +92,24 @@ export function buildDelegationSection(disabled: Set<string>): string {
   }
   if (isAgentEnabled("weft", disabled)) {
     let weftLine = "- Use Weft for reviewing completed work or validating plans before execution"
+    if (weftVariants.length > 0) {
+      weftLine += `; also delegate visible Weft code-quality variants: ${formatReviewVariantList(weftVariants)}. These are Weft reviewers only — never label or use weft-review-* variants as Warp/security audits.`
+    }
     if (isAgentEnabled("warp", disabled)) {
       weftLine +=
-        "\n  - MUST use Warp for security audits when changes touch auth, crypto, certificates, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional. When in doubt, invoke Warp — false positives (fast APPROVE) are cheap."
+        "\n  - MUST use Warp for security audits when changes touch auth, crypto, certificates, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional. Use subagent_type \"warp\" for security unless warp-review-* variants are explicitly listed. Never substitute a weft-review-* variant for Warp."
+      if (warpVariants.length > 0) {
+        weftLine += ` Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}.`
+      }
     }
     lines.push(weftLine)
   } else if (isAgentEnabled("warp", disabled)) {
     // Warp without Weft — still mention Warp
-    lines.push(
-      "- MUST use Warp for security audits when changes touch auth, crypto, certificates, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional.",
-    )
+    let warpLine = "- MUST use Warp for security audits when changes touch auth, crypto, tokens, signatures, input validation, secrets, passwords, sessions, CORS, CSP, .env files, or OAuth/OIDC/SAML flows — not optional."
+    if (warpVariants.length > 0) {
+      warpLine += ` Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}.`
+    }
+    lines.push(warpLine)
   }
   lines.push("- Delegate aggressively to keep your context lean")
 
@@ -121,11 +135,13 @@ When delegating:
 </DelegationNarration>`
 }
 
-export function buildPlanWorkflowSection(disabled: Set<string>): string {
+export function buildPlanWorkflowSection(disabled: Set<string>, reviewModelVariants: ReviewModelVariant[] = []): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
   const hasTapestry = isAgentEnabled("tapestry", disabled)
   const hasPattern = isAgentEnabled("pattern", disabled)
+  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
+  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
   const steps: string[] = []
 
@@ -136,9 +152,16 @@ export function buildPlanWorkflowSection(disabled: Set<string>): string {
   if (hasWeft || hasWarp) {
     const stepNum = hasPattern ? 2 : 1
     const reviewers: string[] = []
-    if (hasWeft) reviewers.push("Weft")
-    if (hasWarp) reviewers.push("Warp for security-relevant plans")
-    steps.push(`${stepNum}. REVIEW: Delegate to ${reviewers.join(", ")} to validate the plan`)
+    if (hasWeft) {
+      reviewers.push(weftVariants.length > 0 ? `Weft plus ${formatReviewVariantList(weftVariants)} for code-quality/plan review only` : "Weft")
+    }
+    if (hasWarp) {
+      reviewers.push(warpVariants.length > 0 ? `Warp plus ${formatReviewVariantList(warpVariants)} for security-relevant plans` : "Warp for security-relevant plans")
+    }
+    const boundary = weftVariants.length > 0
+      ? " Do not use weft-review-* variants as Warp/security reviewers."
+      : ""
+    steps.push(`${stepNum}. REVIEW: Delegate to ${reviewers.join(", ")} to validate the plan.${boundary}`)
   }
 
   if (hasTapestry) {
@@ -159,9 +182,11 @@ Skip it for quick fixes, single-file changes, and simple questions.
 </PlanWorkflow>`
 }
 
-export function buildReviewWorkflowSection(disabled: Set<string>): string {
+export function buildReviewWorkflowSection(disabled: Set<string>, reviewModelVariants: ReviewModelVariant[] = []): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
+  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
+  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
   if (!hasWeft && !hasWarp) return ""
 
@@ -169,9 +194,16 @@ export function buildReviewWorkflowSection(disabled: Set<string>): string {
 
   if (hasWeft) {
     lines.push("- Delegate to Weft after non-trivial changes (3+ files, or when quality matters)")
+    if (weftVariants.length > 0) {
+      lines.push(`- Also delegate visible Weft code-quality variants: ${formatReviewVariantList(weftVariants)}`)
+      lines.push("- Never label or use weft-review-* variants as Warp/security audits")
+    }
   }
   if (hasWarp) {
-    lines.push("- Warp is mandatory when changes touch auth, crypto, tokens, secrets, or input validation")
+    lines.push("- Warp is mandatory when changes touch auth, crypto, tokens, secrets, or input validation; use subagent_type \"warp\" unless warp-review-* variants are configured")
+    if (warpVariants.length > 0) {
+      lines.push(`- Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}`)
+    }
   }
 
   return `<ReviewWorkflow>
@@ -273,18 +305,19 @@ export function composeLoomPrompt(options: LoomPromptOptions = {}): string {
   const fingerprint = options.fingerprint
   const customAgents = options.customAgents ?? []
   const categories = options.categories
+  const reviewModelVariants = options.reviewModelVariants ?? []
 
   const sections = [
     buildRoleSection(),
     buildProjectContextSection(fingerprint),
     buildDisciplineSection(),
     buildSidebarTodosSection(),
-    buildDelegationSection(disabled),
+    buildDelegationSection(disabled, reviewModelVariants),
     buildDelegationNarrationSection(disabled),
     buildCategoryRoutingSection(categories, disabled),
     buildCustomAgentDelegationSection(customAgents, disabled),
-    buildPlanWorkflowSection(disabled),
-    buildReviewWorkflowSection(disabled),
+    buildPlanWorkflowSection(disabled, reviewModelVariants),
+    buildReviewWorkflowSection(disabled, reviewModelVariants),
     buildStyleSection(),
   ].filter((s) => s.length > 0)
 

--- a/src/agents/loom/prompt-composer.ts
+++ b/src/agents/loom/prompt-composer.ts
@@ -197,12 +197,14 @@ export function buildReviewWorkflowSection(disabled: Set<string>, reviewModelVar
     if (weftVariants.length > 0) {
       lines.push(`- Also delegate visible Weft code-quality variants: ${formatReviewVariantList(weftVariants)}`)
       lines.push("- Never label or use weft-review-* variants as Warp/security audits")
+      lines.push("- Multi-review batch rule: when delegating to Weft plus variants, issue all Weft Task calls in the same assistant turn before waiting for any result; do not run only the first reviewer and stop")
     }
   }
   if (hasWarp) {
     lines.push("- Warp is mandatory when changes touch auth, crypto, tokens, secrets, or input validation; use subagent_type \"warp\" unless warp-review-* variants are configured")
     if (warpVariants.length > 0) {
       lines.push(`- Also delegate visible Warp model variants: ${formatReviewVariantList(warpVariants)}`)
+      lines.push("- Multi-review batch rule: when delegating to Warp plus variants, issue all Warp Task calls in the same assistant turn before waiting for any result")
     }
   }
 

--- a/src/agents/review-model-variants.ts
+++ b/src/agents/review-model-variants.ts
@@ -1,0 +1,123 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentOverrideConfig } from "../config/schema"
+
+export type ReviewBaseAgent = "weft" | "warp"
+
+export interface ReviewModelVariant {
+  baseAgent: ReviewBaseAgent
+  key: string
+  model: string
+  label: string
+}
+
+type AgentConfigWithOptions = AgentConfig & {
+  options?: Record<string, unknown>
+}
+
+const REVIEW_BASE_AGENTS = ["weft", "warp"] as const
+
+/**
+ * Build visible subagent variants from agents.weft/warp.review_models.
+ *
+ * Example:
+ *   agents.weft.review_models = ["opencode-go/kimi-k2.6"]
+ *   -> subagent_type "weft-review-opencode-go-kimi-k2-6"
+ */
+export function buildReviewModelVariants(
+  agentOverrides: Record<string, AgentOverrideConfig> | undefined,
+  disabledAgents: Set<string> = new Set(),
+): ReviewModelVariant[] {
+  const seenKeys = new Set<string>()
+  const variants: ReviewModelVariant[] = []
+
+  for (const baseAgent of REVIEW_BASE_AGENTS) {
+    if (disabledAgents.has(baseAgent)) continue
+
+    const override = agentOverrides?.[baseAgent]
+    const reviewModels = override?.review_models ?? []
+    const primaryModel = override?.model
+    const seenModels = new Set<string>()
+
+    for (const model of reviewModels) {
+      if (model === primaryModel) continue
+      if (seenModels.has(model)) continue
+      seenModels.add(model)
+
+      const key = buildUniqueVariantKey(baseAgent, model, seenKeys)
+      if (disabledAgents.has(key)) continue
+
+      seenKeys.add(key)
+      variants.push({
+        baseAgent,
+        key,
+        model,
+        label: `${baseAgent} @ ${model}`,
+      })
+    }
+  }
+
+  return variants
+}
+
+export function buildReviewModelVariantAgent(
+  baseConfig: AgentConfig,
+  variant: ReviewModelVariant,
+): AgentConfig {
+  const { options: _baseModelOptions, ...baseWithoutOptions } = baseConfig as AgentConfigWithOptions
+  const boundary = variant.baseAgent === "weft"
+    ? "You are a Weft code-quality/plan reviewer, not Warp. Do NOT label your work as a security audit. Security audits must use Warp or a warp-review-* variant."
+    : "You are a Warp security reviewer, not Weft. Focus on security/specification concerns and self-triage as Warp normally does."
+  const prompt = [
+    baseWithoutOptions.prompt,
+    `<ReviewVariant>
+You are ${variant.label}, a visible independent ${variant.baseAgent.toUpperCase()} review variant.
+Review the same input independently using model ${variant.model}.
+Return a complete standalone review with your own APPROVE or REJECT verdict.
+${boundary}
+Do not mention or wait for other review variants.
+</ReviewVariant>`,
+  ].filter(Boolean).join("\n\n")
+
+  return {
+    ...baseWithoutOptions,
+    model: variant.model,
+    mode: "subagent",
+    description: `${variant.label} (visible multi-review variant)`,
+    prompt,
+  }
+}
+
+export function reviewVariantsFor(
+  variants: ReviewModelVariant[] | undefined,
+  baseAgent: ReviewBaseAgent,
+): ReviewModelVariant[] {
+  return (variants ?? []).filter((variant) => variant.baseAgent === baseAgent)
+}
+
+export function formatReviewVariantList(variants: ReviewModelVariant[]): string {
+  return variants
+    .map((variant) => `${variant.label} (subagent_type "${variant.key}")`)
+    .join(", ")
+}
+
+function buildUniqueVariantKey(baseAgent: ReviewBaseAgent, model: string, seenKeys: Set<string>): string {
+  const baseKey = sanitizeAgentKey(`${baseAgent}-review-${model.replace("/", "-")}`)
+  let key = baseKey
+  let suffix = 2
+
+  while (seenKeys.has(key)) {
+    key = `${baseKey}-${suffix++}`
+  }
+
+  return key
+}
+
+function sanitizeAgentKey(value: string): string {
+  const key = value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "")
+
+  return /^[a-z]/.test(key) ? key : `review-${key}`
+}

--- a/src/agents/review-orchestrator.test.ts
+++ b/src/agents/review-orchestrator.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, mock } from "bun:test"
+import {
+  buildFailureWarning,
+  collateReviews,
+  runAdditionalReviewers,
+  type ReviewResult,
+  type RunAdditionalReviewersInput,
+} from "./review-orchestrator"
+
+type MockClient = RunAdditionalReviewersInput["client"] & {
+  session: {
+    create: ReturnType<typeof mock>
+    prompt: ReturnType<typeof mock>
+  }
+}
+
+function makeClient(overrides?: Partial<MockClient["session"]>): MockClient {
+  const session = {
+    create: mock(async () => ({ data: { id: "session-1" } })),
+    prompt: mock(async () => ({ data: { output: "Collated review" } })),
+    ...overrides,
+  }
+
+  return { session } as MockClient
+}
+
+function makeCreateMock(...sessionIds: string[]) {
+  let index = 0
+
+  return mock(async () => ({ data: { id: sessionIds[index++] ?? `session-${index}` } }))
+}
+
+async function finalizeReview(input: {
+  agentName: string
+  primaryModel: string
+  primaryOutput: string
+  additionalResults: ReviewResult[]
+  originalContext: string
+  reviewModels: string[]
+  client: RunAdditionalReviewersInput["client"]
+}): Promise<string> {
+  const failedCount = input.additionalResults.filter((result) => !result.success).length
+  const allFailed = failedCount >= input.additionalResults.length
+
+  if (allFailed) {
+    return `${buildFailureWarning({ totalAdditional: input.reviewModels.length, failedCount })}\n\n${input.primaryOutput}`
+  }
+
+  const collated = await collateReviews({
+    agentName: input.agentName,
+    primaryModel: input.primaryModel,
+    primaryOutput: input.primaryOutput,
+    additionalResults: input.additionalResults,
+    originalContext: input.originalContext,
+    client: input.client,
+  })
+  const warning = failedCount > 0
+    ? `${buildFailureWarning({ totalAdditional: input.reviewModels.length, failedCount })}\n\n`
+    : ""
+
+  return warning + collated
+}
+
+describe("runAdditionalReviewers", () => {
+  it("returns empty results immediately when reviewModels is empty", async () => {
+    const client = makeClient()
+
+    const results = await runAdditionalReviewers({
+      agentName: "loom",
+      reviewModels: [],
+      prompt: "Review this change",
+      client,
+    })
+
+    expect(results).toEqual([])
+    expect(client.session.create).not.toHaveBeenCalled()
+    expect(client.session.prompt).not.toHaveBeenCalled()
+  })
+
+  it("collects successful additional reviewer outputs for collation", async () => {
+    const create = makeCreateMock("review-1", "review-2", "collate-1")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "review-1") {
+        return { data: { output: "Secondary review A" } }
+      }
+
+      if (sessionId === "review-2") {
+        return { data: { output: "Secondary review B" } }
+      }
+
+      return { data: { output: "Merged review from three models" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const additionalResults = await runAdditionalReviewers({
+      agentName: "loom",
+      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      prompt: "Review this PR",
+      client,
+    })
+
+    expect(additionalResults).toEqual([
+      { model: "anthropic/claude-sonnet-4", output: "Secondary review A", success: true },
+      { model: "google/gemini-2.5-pro", output: "Secondary review B", success: true },
+    ])
+
+    const finalOutput = await finalizeReview({
+      agentName: "loom",
+      primaryModel: "openai/gpt-4o",
+      primaryOutput: "Primary review",
+      additionalResults,
+      originalContext: "Original review request",
+      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      client,
+    })
+
+    expect(finalOutput).toBe("Merged review from three models")
+    expect(prompt).toHaveBeenCalledTimes(3)
+
+    const collateRequest = prompt.mock.calls[2]?.[0] as {
+      body?: { model?: { providerID: string; modelID: string }; parts?: Array<{ text?: string }> }
+    }
+    const promptText = collateRequest.body?.parts?.[0]?.text ?? ""
+
+    expect(collateRequest.body?.model).toEqual({ providerID: "openai", modelID: "gpt-4o" })
+    expect(promptText).toContain("## Primary reviewer: openai/gpt-4o")
+    expect(promptText).toContain("Primary review")
+    expect(promptText).toContain("## Additional reviewer: anthropic/claude-sonnet-4")
+    expect(promptText).toContain("Secondary review A")
+    expect(promptText).toContain("## Additional reviewer: google/gemini-2.5-pro")
+    expect(promptText).toContain("Secondary review B")
+    expect(promptText).toContain("## Failed additional reviewers")
+    expect(promptText).toContain("- None")
+  })
+
+  it("returns successful outputs plus a prepended partial failure warning when one reviewer fails", async () => {
+    const create = makeCreateMock("review-1", "review-2", "collate-1")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "review-1") {
+        return { data: { output: "Secondary review A" } }
+      }
+
+      if (sessionId === "review-2") {
+        throw new Error("secondary reviewer unavailable")
+      }
+
+      return { data: { output: "Merged review from two models" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const additionalResults = await runAdditionalReviewers({
+      agentName: "loom",
+      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      prompt: "Review this PR",
+      client,
+    })
+
+    expect(additionalResults).toEqual([
+      { model: "anthropic/claude-sonnet-4", output: "Secondary review A", success: true },
+      {
+        model: "google/gemini-2.5-pro",
+        output: "",
+        success: false,
+        error: "secondary reviewer unavailable",
+      },
+    ])
+
+    const finalOutput = await finalizeReview({
+      agentName: "loom",
+      primaryModel: "openai/gpt-4o",
+      primaryOutput: "Primary review",
+      additionalResults,
+      originalContext: "Original review request",
+      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      client,
+    })
+
+    expect(finalOutput).toBe(
+      "⚠️ 1 of 2 additional review models did not respond. Results based on 2 models (including primary).\n\nMerged review from two models",
+    )
+    expect(prompt).toHaveBeenCalledTimes(3)
+
+    const collateRequest = prompt.mock.calls[2]?.[0] as { body?: { parts?: Array<{ text?: string }> } }
+    const promptText = collateRequest.body?.parts?.[0]?.text ?? ""
+
+    expect(promptText).toContain("## Additional reviewer: anthropic/claude-sonnet-4")
+    expect(promptText).toContain("Secondary review A")
+    expect(promptText).not.toContain("## Additional reviewer: google/gemini-2.5-pro")
+    expect(promptText).toContain("- google/gemini-2.5-pro: secondary reviewer unavailable")
+  })
+
+  it("returns the primary output with a total failure warning when all reviewers fail", async () => {
+    const create = makeCreateMock("review-1", "review-2")
+    const prompt = mock(async () => {
+      throw new Error("reviewer offline")
+    })
+    const client = makeClient({ create, prompt })
+
+    const additionalResults = await runAdditionalReviewers({
+      agentName: "loom",
+      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      prompt: "Review this PR",
+      client,
+    })
+
+    expect(additionalResults).toEqual([
+      { model: "anthropic/claude-sonnet-4", output: "", success: false, error: "reviewer offline" },
+      { model: "google/gemini-2.5-pro", output: "", success: false, error: "reviewer offline" },
+    ])
+
+    const finalOutput = await finalizeReview({
+      agentName: "loom",
+      primaryModel: "openai/gpt-4o",
+      primaryOutput: "Primary review only",
+      additionalResults,
+      originalContext: "Original review request",
+      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      client,
+    })
+
+    expect(finalOutput).toBe(
+      "⚠️ All 2 additional review models failed. Showing primary model review only.\n\nPrimary review only",
+    )
+    expect(prompt).toHaveBeenCalledTimes(2)
+  })
+
+  it("treats a reviewer with no output as a failure", async () => {
+    const create = makeCreateMock("review-1")
+    const prompt = mock(async () => ({ data: { output: "" } }))
+    const client = makeClient({ create, prompt })
+
+    const [result] = await runAdditionalReviewers({
+      agentName: "loom",
+      reviewModels: ["anthropic/claude-sonnet-4"],
+      prompt: "Review this PR",
+      client,
+    })
+
+    expect(result).toEqual({
+      model: "anthropic/claude-sonnet-4",
+      output: "",
+      success: false,
+      error: "Reviewer anthropic/claude-sonnet-4 returned no output",
+    })
+  })
+})
+
+describe("buildFailureWarning", () => {
+  it("returns the exact partial failure warning string", () => {
+    expect(buildFailureWarning({ totalAdditional: 2, failedCount: 1 })).toBe(
+      "⚠️ 1 of 2 additional review models did not respond. Results based on 2 models (including primary).",
+    )
+  })
+
+  it("returns the exact total failure warning string", () => {
+    expect(buildFailureWarning({ totalAdditional: 2, failedCount: 2 })).toBe(
+      "⚠️ All 2 additional review models failed. Showing primary model review only.",
+    )
+  })
+})

--- a/src/agents/review-orchestrator.test.ts
+++ b/src/agents/review-orchestrator.test.ts
@@ -3,9 +3,11 @@ import {
   buildFailureWarning,
   collateReviews,
   runAdditionalReviewers,
+  runReviewerFanOut,
   type ReviewResult,
   type RunAdditionalReviewersInput,
 } from "./review-orchestrator"
+import type { ReviewerPlan } from "./review-resolver"
 
 type MockClient = RunAdditionalReviewersInput["client"] & {
   session: {
@@ -28,6 +30,10 @@ function makeCreateMock(...sessionIds: string[]) {
   let index = 0
 
   return mock(async () => ({ data: { id: sessionIds[index++] ?? `session-${index}` } }))
+}
+
+function reviewerEntries(models: string[], agentName = "loom") {
+  return models.map((model) => ({ agentName, model }))
 }
 
 async function finalizeReview(input: {
@@ -62,12 +68,73 @@ async function finalizeReview(input: {
 }
 
 describe("runAdditionalReviewers", () => {
-  it("returns empty results immediately when reviewModels is empty", async () => {
+  it("uses each reviewer entry's agentName in prompt request body", async () => {
+    const create = makeCreateMock("review-1", "review-2")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "review-1") {
+        return { data: { output: "Review from agent A" } }
+      }
+
+      return { data: { output: "Review from agent B" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const results = await runAdditionalReviewers({
+      reviewers: [
+        { agentName: "loom", model: "anthropic/claude-sonnet-4" },
+        { agentName: "warp", model: "google/gemini-2.5-pro" },
+      ],
+      prompt: "Review this change",
+      client,
+    })
+
+    expect(results).toEqual([
+      { model: "anthropic/claude-sonnet-4", output: "Review from agent A", success: true },
+      { model: "google/gemini-2.5-pro", output: "Review from agent B", success: true },
+    ])
+
+    const firstPrompt = prompt.mock.calls[0]?.[0] as { body?: { agent?: string } }
+    const secondPrompt = prompt.mock.calls[1]?.[0] as { body?: { agent?: string } }
+
+    expect(firstPrompt.body?.agent).toBe("loom")
+    expect(secondPrompt.body?.agent).toBe("warp")
+  })
+
+  it("creates distinct session titles when reviewer entries use different agent names", async () => {
+    const create = mock(async (input?: Record<string, unknown>) => {
+      const title = (input?.title as string | undefined) ?? "session"
+      return { data: { id: `session-${title}` } }
+    })
+    const client = makeClient({
+      create,
+      prompt: mock(async () => ({ data: { output: "ok" } })),
+    })
+
+    await runAdditionalReviewers({
+      reviewers: [
+        { agentName: "loom", model: "openai/gpt-4o" },
+        { agentName: "warp", model: "openai/gpt-4o" },
+      ],
+      prompt: "Review this change",
+      client,
+    })
+
+    expect(create).toHaveBeenCalledTimes(2)
+
+    const firstTitle = create.mock.calls[0]?.[0]?.title
+    const secondTitle = create.mock.calls[1]?.[0]?.title
+
+    expect(firstTitle).toBe("loom-review-openai-gpt-4o")
+    expect(secondTitle).toBe("warp-review-openai-gpt-4o")
+    expect(firstTitle).not.toBe(secondTitle)
+  })
+
+  it("returns empty results immediately when reviewers is empty", async () => {
     const client = makeClient()
 
     const results = await runAdditionalReviewers({
-      agentName: "loom",
-      reviewModels: [],
+      reviewers: [],
       prompt: "Review this change",
       client,
     })
@@ -94,8 +161,7 @@ describe("runAdditionalReviewers", () => {
     const client = makeClient({ create, prompt })
 
     const additionalResults = await runAdditionalReviewers({
-      agentName: "loom",
-      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      reviewers: reviewerEntries(["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"]),
       prompt: "Review this PR",
       client,
     })
@@ -151,8 +217,7 @@ describe("runAdditionalReviewers", () => {
     const client = makeClient({ create, prompt })
 
     const additionalResults = await runAdditionalReviewers({
-      agentName: "loom",
-      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      reviewers: reviewerEntries(["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"]),
       prompt: "Review this PR",
       client,
     })
@@ -199,8 +264,7 @@ describe("runAdditionalReviewers", () => {
     const client = makeClient({ create, prompt })
 
     const additionalResults = await runAdditionalReviewers({
-      agentName: "loom",
-      reviewModels: ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"],
+      reviewers: reviewerEntries(["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"]),
       prompt: "Review this PR",
       client,
     })
@@ -232,8 +296,7 @@ describe("runAdditionalReviewers", () => {
     const client = makeClient({ create, prompt })
 
     const [result] = await runAdditionalReviewers({
-      agentName: "loom",
-      reviewModels: ["anthropic/claude-sonnet-4"],
+      reviewers: reviewerEntries(["anthropic/claude-sonnet-4"]),
       prompt: "Review this PR",
       client,
     })
@@ -244,6 +307,353 @@ describe("runAdditionalReviewers", () => {
       success: false,
       error: "Reviewer anthropic/claude-sonnet-4 returned no output",
     })
+  })
+
+  it("sends each reviewer's agentName in the prompt request body", async () => {
+    const create = makeCreateMock("review-1", "review-2")
+    const prompt = mock(async () => ({ data: { output: "Secondary review" } }))
+    const client = makeClient({ create, prompt })
+
+    await runAdditionalReviewers({
+      reviewers: [
+        { agentName: "loom", model: "anthropic/claude-sonnet-4" },
+        { agentName: "weft", model: "google/gemini-2.5-pro" },
+      ],
+      prompt: "Review this PR",
+      client,
+    })
+
+    const firstRequest = prompt.mock.calls[0]?.[0] as { body?: { agent?: string } }
+    const secondRequest = prompt.mock.calls[1]?.[0] as { body?: { agent?: string } }
+
+    expect(firstRequest.body?.agent).toBe("loom")
+    expect(secondRequest.body?.agent).toBe("weft")
+  })
+
+  it("creates distinct session titles when reviewers use different agent names", async () => {
+    const create = makeCreateMock("review-1", "review-2")
+    const prompt = mock(async () => ({ data: { output: "Secondary review" } }))
+    const client = makeClient({ create, prompt })
+
+    await runAdditionalReviewers({
+      reviewers: [
+        { agentName: "loom", model: "anthropic/claude-sonnet-4" },
+        { agentName: "weft", model: "anthropic/claude-sonnet-4" },
+      ],
+      prompt: "Review this PR",
+      client,
+    })
+
+    const firstCreate = create.mock.calls[0]?.[0] as { title?: string }
+    const secondCreate = create.mock.calls[1]?.[0] as { title?: string }
+
+    expect(firstCreate.title).toBe("loom-review-anthropic-claude-sonnet-4")
+    expect(secondCreate.title).toBe("weft-review-anthropic-claude-sonnet-4")
+    expect(firstCreate.title).not.toBe(secondCreate.title)
+  })
+
+})
+
+describe("runReviewerFanOut", () => {
+  const promptText = "Please review this patch"
+  const originalContext = "Review the code changes for correctness and risk"
+
+  function fanOutPlan(scope: "direct" | "post-execution"): ReviewerPlan {
+    return {
+      kind: "fan-out",
+      scope,
+      baseAgent: "weft",
+      primary: {
+        agentName: "weft",
+        label: "Weft",
+        model: "openai/gpt-4o",
+      },
+      variants: [
+        {
+          baseAgent: "weft",
+          key: "weft-review-anthropic-claude-sonnet-4",
+          model: "anthropic/claude-sonnet-4",
+          label: "weft @ anthropic/claude-sonnet-4",
+        },
+        {
+          baseAgent: "weft",
+          key: "weft-review-google-gemini-2-5-pro",
+          model: "google/gemini-2.5-pro",
+          label: "weft @ google/gemini-2.5-pro",
+        },
+      ],
+      batch: { mode: "parallel", size: 3 },
+    }
+  }
+
+  function primaryOnlyPlan(scope: "direct" | "post-execution"): ReviewerPlan {
+    return {
+      kind: "primary-only",
+      scope,
+      baseAgent: "weft",
+      primary: {
+        agentName: "weft",
+        label: "Weft",
+        model: "openai/gpt-4o",
+      },
+      reason: "no-variants",
+    }
+  }
+
+  function disabledPlan(scope: "direct" | "post-execution"): ReviewerPlan {
+    return {
+      kind: "disabled",
+      scope,
+      baseAgent: "weft",
+      reason: "agent-disabled",
+    }
+  }
+
+  it("fan-out direct with captured primary creates variant sessions only and collates with captured primary", async () => {
+    const capturedPrimaryOutput = "Captured primary output"
+    const create = makeCreateMock("variant-1", "variant-2", "collate-1")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "variant-1") return { data: { output: "Variant output A" } }
+      if (sessionId === "variant-2") return { data: { output: "Variant output B" } }
+      return { data: { output: "Collated fan-out output" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const result = await runReviewerFanOut({
+      plan: fanOutPlan("direct"),
+      capturedPrimaryOutput,
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result).toEqual({
+      output: "Collated fan-out output",
+      failureWarning: null,
+      ran: [
+        "weft",
+        "weft-review-anthropic-claude-sonnet-4",
+        "weft-review-google-gemini-2-5-pro",
+      ],
+    })
+    expect(create).toHaveBeenCalledTimes(3)
+    expect(prompt).toHaveBeenCalledTimes(3)
+
+    const variantPrompt1 = (prompt.mock.calls[0]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    const variantPrompt2 = (prompt.mock.calls[1]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    expect(variantPrompt1).toContain(promptText)
+    expect(variantPrompt1).not.toContain(capturedPrimaryOutput)
+    expect(variantPrompt2).toContain(promptText)
+    expect(variantPrompt2).not.toContain(capturedPrimaryOutput)
+
+    const collatePrompt = (prompt.mock.calls[2]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    expect(collatePrompt).toContain("## Primary reviewer: openai/gpt-4o")
+    expect(collatePrompt).toContain(capturedPrimaryOutput)
+  })
+
+  it("fan-out post-execution runs 1+N+1 calls and reviewers receive promptText", async () => {
+    const create = makeCreateMock("primary-1", "variant-1", "variant-2", "collate-1")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "primary-1") return { data: { output: "Primary generated output" } }
+      if (sessionId === "variant-1") return { data: { output: "Variant output A" } }
+      if (sessionId === "variant-2") return { data: { output: "Variant output B" } }
+      return { data: { output: "Collated post-execution output" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const result = await runReviewerFanOut({
+      plan: fanOutPlan("post-execution"),
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result.output).toBe("Collated post-execution output")
+    expect(result.failureWarning).toBeNull()
+    expect(result.ran).toEqual([
+      "weft",
+      "weft-review-anthropic-claude-sonnet-4",
+      "weft-review-google-gemini-2-5-pro",
+    ])
+    expect(create).toHaveBeenCalledTimes(4)
+    expect(prompt).toHaveBeenCalledTimes(4)
+
+    const primaryPrompt = (prompt.mock.calls[0]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    const variantPrompt1 = (prompt.mock.calls[1]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    const variantPrompt2 = (prompt.mock.calls[2]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    expect(primaryPrompt).toContain(promptText)
+    expect(variantPrompt1).toContain(promptText)
+    expect(variantPrompt2).toContain(promptText)
+  })
+
+  it("primary-only direct with captured output returns captured text without any session calls", async () => {
+    const client = makeClient()
+
+    const result = await runReviewerFanOut({
+      plan: primaryOnlyPlan("direct"),
+      capturedPrimaryOutput: "Primary captured review",
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result).toEqual({
+      output: "Primary captured review",
+      failureWarning: null,
+      ran: ["weft"],
+    })
+    expect(client.session.create).toHaveBeenCalledTimes(0)
+    expect(client.session.prompt).toHaveBeenCalledTimes(0)
+  })
+
+  it("primary-only post-execution runs exactly one reviewer session and prompt with no collation", async () => {
+    const create = makeCreateMock("primary-1")
+    const prompt = mock(async () => ({ data: { output: "Primary output" } }))
+    const client = makeClient({ create, prompt })
+
+    const result = await runReviewerFanOut({
+      plan: primaryOnlyPlan("post-execution"),
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result).toEqual({
+      output: "Primary output",
+      failureWarning: null,
+      ran: ["weft"],
+    })
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(prompt).toHaveBeenCalledTimes(1)
+
+    const requestPrompt = (prompt.mock.calls[0]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    expect(requestPrompt).toContain(promptText)
+  })
+
+  it("disabled plan in either scope returns empty output with zero calls", async () => {
+    const client = makeClient()
+
+    const directResult = await runReviewerFanOut({
+      plan: disabledPlan("direct"),
+      capturedPrimaryOutput: "ignored",
+      promptText,
+      originalContext,
+      client,
+    })
+    const postResult = await runReviewerFanOut({
+      plan: disabledPlan("post-execution"),
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(directResult).toEqual({ output: "", failureWarning: null, ran: [] })
+    expect(postResult).toEqual({ output: "", failureWarning: null, ran: [] })
+    expect(client.session.create).toHaveBeenCalledTimes(0)
+    expect(client.session.prompt).toHaveBeenCalledTimes(0)
+  })
+
+  it("fan-out direct with one failing variant sets warning and collates partial with captured primary", async () => {
+    const capturedPrimaryOutput = "Captured direct primary"
+    const create = makeCreateMock("variant-1", "variant-2", "collate-1")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "variant-1") return { data: { output: "Variant success" } }
+      if (sessionId === "variant-2") throw new Error("variant down")
+      return { data: { output: "Collated partial" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const result = await runReviewerFanOut({
+      plan: fanOutPlan("direct"),
+      capturedPrimaryOutput,
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result.failureWarning).toBe(
+      "⚠️ 1 of 2 additional review models did not respond. Results based on 2 models (including primary).\n\nFailed reviewers:\n- google/gemini-2.5-pro: variant down",
+    )
+    expect(result.output).toContain("Collated partial")
+    const collatePrompt = (prompt.mock.calls[2]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    expect(collatePrompt).toContain(capturedPrimaryOutput)
+    expect(collatePrompt).toContain("## Additional reviewer: anthropic/claude-sonnet-4")
+    expect(collatePrompt).not.toContain("## Additional reviewer: google/gemini-2.5-pro")
+    expect(collatePrompt).toContain("- google/gemini-2.5-pro: variant down")
+  })
+
+  it("fan-out post-execution with failed primary and one successful variant still collates with warning", async () => {
+    const create = makeCreateMock("primary-1", "variant-1", "variant-2", "collate-1")
+    const prompt = mock(async (input: Record<string, unknown>) => {
+      const sessionId = ((input.path as { id?: string } | undefined)?.id) ?? ""
+      if (sessionId === "primary-1") throw new Error("primary failed")
+      if (sessionId === "variant-1") return { data: { output: "Variant survives" } }
+      if (sessionId === "variant-2") throw new Error("variant failed")
+      return { data: { output: "Collated surviving variant" } }
+    })
+    const client = makeClient({ create, prompt })
+
+    const result = await runReviewerFanOut({
+      plan: fanOutPlan("post-execution"),
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result.failureWarning).toBe(
+      "⚠️ 1 of 2 additional review models did not respond. Results based on 2 models (including primary).\n\nFailed reviewers:\n- google/gemini-2.5-pro: variant failed",
+    )
+    expect(result.output).toContain("Collated surviving variant")
+    expect(result.ran).toEqual(["weft-review-anthropic-claude-sonnet-4"])
+    expect(create).toHaveBeenCalledTimes(4)
+    expect(prompt).toHaveBeenCalledTimes(4)
+
+    const collatePrompt = (prompt.mock.calls[3]?.[0] as { body?: { parts?: Array<{ text?: string }> } }).body?.parts?.[0]?.text ?? ""
+    expect(collatePrompt).toContain("## Additional reviewer: anthropic/claude-sonnet-4")
+    expect(collatePrompt).toContain("Variant survives")
+    expect(collatePrompt).toContain("- google/gemini-2.5-pro: variant failed")
+  })
+
+  it("fan-out post-execution with all failures returns empty output, warning, and no collation", async () => {
+    const create = makeCreateMock("primary-1", "variant-1", "variant-2")
+    const prompt = mock(async () => {
+      throw new Error("offline")
+    })
+    const client = makeClient({ create, prompt })
+
+    const result = await runReviewerFanOut({
+      plan: fanOutPlan("post-execution"),
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result).toEqual({
+      output: "",
+      failureWarning:
+        "⚠️ All 2 additional review models failed. Showing primary model review only.\n\nFailed reviewers:\n- anthropic/claude-sonnet-4: offline\n- google/gemini-2.5-pro: offline",
+      ran: [],
+    })
+    expect(create).toHaveBeenCalledTimes(3)
+    expect(prompt).toHaveBeenCalledTimes(3)
+  })
+
+  it("primary-only direct without captured output returns empty defensive result", async () => {
+    const client = makeClient()
+
+    const result = await runReviewerFanOut({
+      plan: primaryOnlyPlan("direct"),
+      promptText,
+      originalContext,
+      client,
+    })
+
+    expect(result).toEqual({ output: "", failureWarning: null, ran: [] })
+    expect(client.session.create).toHaveBeenCalledTimes(0)
+    expect(client.session.prompt).toHaveBeenCalledTimes(0)
   })
 })
 

--- a/src/agents/review-orchestrator.ts
+++ b/src/agents/review-orchestrator.ts
@@ -1,4 +1,5 @@
 import type { PluginContext } from "../plugin/types"
+import type { ReviewerPlan } from "./review-resolver"
 
 export interface ReviewResult {
   model: string
@@ -8,10 +9,14 @@ export interface ReviewResult {
 }
 
 export interface RunAdditionalReviewersInput {
-  agentName: string
-  reviewModels: string[]
+  reviewers: ReviewerEntry[]
   prompt: string
   client: PluginContext["client"]
+}
+
+export interface ReviewerEntry {
+  agentName: string
+  model: string
 }
 
 export interface CollateReviewsInput {
@@ -37,11 +42,11 @@ type ReviewClient = {
 }
 
 export async function runAdditionalReviewers(input: RunAdditionalReviewersInput): Promise<ReviewResult[]> {
-  const { agentName, reviewModels, prompt, client } = input
+  const { reviewers, prompt, client } = input
   const reviewClient = client as unknown as ReviewClient
 
   const settledResults = await Promise.allSettled(
-    reviewModels.map((model) => runSingleReviewer({ agentName, model, prompt, client: reviewClient })),
+    reviewers.map((reviewer) => runSingleReviewer({ reviewer, prompt, client: reviewClient })),
   )
 
   return settledResults.map((result, index) => {
@@ -50,7 +55,7 @@ export async function runAdditionalReviewers(input: RunAdditionalReviewersInput)
     }
 
     return {
-      model: reviewModels[index] ?? "unknown",
+      model: reviewers[index]?.model ?? "unknown",
       output: "",
       success: false,
       error: toErrorMessage(result.reason),
@@ -97,6 +102,188 @@ export function buildFailureWarning(input: BuildFailureWarningInput): string {
   return details ? `${headline}\n\nFailed reviewers:\n${details}` : headline
 }
 
+export async function runReviewerFanOut(input: {
+  plan: ReviewerPlan
+  capturedPrimaryOutput?: string
+  promptText: string
+  originalContext: string
+  client: PluginContext["client"]
+}): Promise<{ output: string; failureWarning: string | null; ran: string[] }> {
+  const { plan, capturedPrimaryOutput, promptText, originalContext, client } = input
+
+  if (plan.kind === "disabled") {
+    return { output: "", failureWarning: null, ran: [] }
+  }
+
+  if (plan.kind === "primary-only") {
+    if (plan.scope === "direct") {
+      if (capturedPrimaryOutput === undefined) {
+        return { output: "", failureWarning: null, ran: [] }
+      }
+
+      return {
+        output: capturedPrimaryOutput,
+        failureWarning: null,
+        ran: [plan.primary.agentName],
+      }
+    }
+
+    const [primaryResult] = await runAdditionalReviewers({
+      reviewers: [{ agentName: plan.primary.agentName, model: plan.primary.model }],
+      prompt: promptText,
+      client,
+    })
+
+    if (!primaryResult?.success) {
+      return { output: "", failureWarning: null, ran: [] }
+    }
+
+    return {
+      output: primaryResult.output,
+      failureWarning: null,
+      ran: [plan.primary.agentName],
+    }
+  }
+
+  const variantEntries: ReviewerEntry[] = plan.variants.map((variant) => ({
+    agentName: variant.key,
+    model: variant.model,
+  }))
+
+  if (plan.scope === "direct") {
+    if (capturedPrimaryOutput === undefined) {
+      return { output: "", failureWarning: null, ran: [] }
+    }
+
+    const additionalResults = await runAdditionalReviewers({
+      reviewers: variantEntries,
+      prompt: promptText,
+      client,
+    })
+
+    const failedAdditional = additionalResults.filter((result) => !result.success)
+    const successfulAdditionalRan = additionalResults
+      .map((result, index) => (result.success ? variantEntries[index]?.agentName : null))
+      .filter((name): name is string => typeof name === "string")
+    const failureWarning = failedAdditional.length > 0
+      ? buildFailureWarning({
+        totalAdditional: variantEntries.length,
+        failedCount: failedAdditional.length,
+        failedResults: failedAdditional,
+      })
+      : null
+
+    if (variantEntries.length > 0 && failedAdditional.length >= variantEntries.length) {
+      return {
+        output: capturedPrimaryOutput,
+        failureWarning,
+        ran: [plan.primary.agentName],
+      }
+    }
+
+    const collated = await collateReviews({
+      agentName: plan.primary.agentName,
+      primaryModel: plan.primary.model,
+      primaryOutput: capturedPrimaryOutput,
+      additionalResults,
+      originalContext,
+      client,
+    })
+
+    return {
+      output: failureWarning ? `${failureWarning}\n\n${collated}` : collated,
+      failureWarning,
+      ran: [
+        plan.primary.agentName,
+        ...successfulAdditionalRan,
+      ],
+    }
+  }
+
+  const allReviewers: ReviewerEntry[] = [
+    { agentName: plan.primary.agentName, model: plan.primary.model },
+    ...variantEntries,
+  ]
+  const reviewResults = await runAdditionalReviewers({
+    reviewers: allReviewers,
+    prompt: promptText,
+    client,
+  })
+
+  const [primaryResult, ...additionalResults] = reviewResults
+  const failedAdditional = additionalResults.filter((result) => !result.success)
+  const successfulAdditionalRan = additionalResults
+    .map((result, index) => (result.success ? variantEntries[index]?.agentName : null))
+    .filter((name): name is string => typeof name === "string")
+  const failureWarning = failedAdditional.length > 0
+    ? buildFailureWarning({
+      totalAdditional: variantEntries.length,
+      failedCount: failedAdditional.length,
+      failedResults: failedAdditional,
+    })
+    : null
+
+  const allFailed = reviewResults.length > 0 && reviewResults.every((result) => !result.success)
+  if (allFailed) {
+    return {
+      output: "",
+      failureWarning,
+      ran: [],
+    }
+  }
+
+  if (primaryResult?.success && failedAdditional.length >= variantEntries.length) {
+    return {
+      output: primaryResult.output,
+      failureWarning,
+      ran: [plan.primary.agentName],
+    }
+  }
+
+  if (!primaryResult?.success) {
+    if (successfulAdditionalRan.length > 0) {
+      const collated = await collateReviews({
+        agentName: plan.primary.agentName,
+        primaryModel: plan.primary.model,
+        primaryOutput: "",
+        additionalResults,
+        originalContext,
+        client,
+      })
+
+      return {
+        output: failureWarning ? `${failureWarning}\n\n${collated}` : collated,
+        failureWarning,
+        ran: successfulAdditionalRan,
+      }
+    }
+
+    return {
+      output: "",
+      failureWarning,
+      ran: successfulAdditionalRan,
+    }
+  }
+
+  const collated = await collateReviews({
+    agentName: plan.primary.agentName,
+    primaryModel: plan.primary.model,
+    primaryOutput: primaryResult.output,
+    additionalResults,
+    originalContext,
+    client,
+  })
+
+  return {
+    output: failureWarning ? `${failureWarning}\n\n${collated}` : collated,
+    failureWarning,
+    ran: [
+      plan.primary.agentName,
+      ...successfulAdditionalRan,
+    ],
+  }
+}
+
 function formatFailureDetails(results: ReviewResult[] | undefined): string {
   const failures = results?.filter((result) => !result.success) ?? []
   return failures
@@ -105,12 +292,12 @@ function formatFailureDetails(results: ReviewResult[] | undefined): string {
 }
 
 async function runSingleReviewer(input: {
-  agentName: string
-  model: string
+  reviewer: ReviewerEntry
   prompt: string
   client: ReviewClient
 }): Promise<ReviewResult> {
-  const { agentName, model, prompt, client } = input
+  const { reviewer, prompt, client } = input
+  const { agentName, model } = reviewer
   const sessionId = await createEphemeralSession(client, `${agentName}-review-${sanitizeModelName(model)}`)
 
   const response = await client.session.prompt(buildPromptRequest({

--- a/src/agents/review-orchestrator.ts
+++ b/src/agents/review-orchestrator.ts
@@ -26,6 +26,7 @@ export interface CollateReviewsInput {
 export interface BuildFailureWarningInput {
   totalAdditional: number
   failedCount: number
+  failedResults?: ReviewResult[]
 }
 
 type ReviewClient = {
@@ -85,12 +86,22 @@ export async function collateReviews(input: CollateReviewsInput): Promise<string
 
 export function buildFailureWarning(input: BuildFailureWarningInput): string {
   const { totalAdditional, failedCount } = input
+  const details = formatFailureDetails(input.failedResults)
 
   if (totalAdditional > 0 && failedCount >= totalAdditional) {
-    return `⚠️ All ${totalAdditional} additional review models failed. Showing primary model review only.`
+    const headline = `⚠️ All ${totalAdditional} additional review models failed. Showing primary model review only.`
+    return details ? `${headline}\n\nFailed reviewers:\n${details}` : headline
   }
 
-  return `⚠️ ${failedCount} of ${totalAdditional} additional review models did not respond. Results based on ${totalAdditional - failedCount + 1} models (including primary).`
+  const headline = `⚠️ ${failedCount} of ${totalAdditional} additional review models did not respond. Results based on ${totalAdditional - failedCount + 1} models (including primary).`
+  return details ? `${headline}\n\nFailed reviewers:\n${details}` : headline
+}
+
+function formatFailureDetails(results: ReviewResult[] | undefined): string {
+  const failures = results?.filter((result) => !result.success) ?? []
+  return failures
+    .map((result) => `- ${result.model}: ${result.error ?? "No response received."}`)
+    .join("\n")
 }
 
 async function runSingleReviewer(input: {

--- a/src/agents/review-orchestrator.ts
+++ b/src/agents/review-orchestrator.ts
@@ -1,0 +1,309 @@
+import type { PluginContext } from "../plugin/types"
+
+export interface ReviewResult {
+  model: string
+  output: string
+  success: boolean
+  error?: string
+}
+
+export interface RunAdditionalReviewersInput {
+  agentName: string
+  reviewModels: string[]
+  prompt: string
+  client: PluginContext["client"]
+}
+
+export interface CollateReviewsInput {
+  agentName: string
+  primaryModel: string
+  primaryOutput: string
+  additionalResults: ReviewResult[]
+  originalContext: string
+  client: PluginContext["client"]
+}
+
+export interface BuildFailureWarningInput {
+  totalAdditional: number
+  failedCount: number
+}
+
+type ReviewClient = {
+  session: {
+    create(input?: Record<string, unknown>): Promise<unknown>
+    prompt(input: Record<string, unknown>): Promise<unknown>
+  }
+}
+
+export async function runAdditionalReviewers(input: RunAdditionalReviewersInput): Promise<ReviewResult[]> {
+  const { agentName, reviewModels, prompt, client } = input
+  const reviewClient = client as unknown as ReviewClient
+
+  const settledResults = await Promise.allSettled(
+    reviewModels.map((model) => runSingleReviewer({ agentName, model, prompt, client: reviewClient })),
+  )
+
+  return settledResults.map((result, index) => {
+    if (result.status === "fulfilled") {
+      return result.value
+    }
+
+    return {
+      model: reviewModels[index] ?? "unknown",
+      output: "",
+      success: false,
+      error: toErrorMessage(result.reason),
+    }
+  })
+}
+
+export async function collateReviews(input: CollateReviewsInput): Promise<string> {
+  const { agentName, primaryModel, primaryOutput, additionalResults, originalContext, client } = input
+  const reviewClient = client as unknown as ReviewClient
+  const sessionId = await createEphemeralSession(reviewClient, "review-collation")
+  const prompt = buildCollationPrompt({
+    primaryModel,
+    primaryOutput,
+    additionalResults,
+    originalContext,
+  })
+
+  const response = await reviewClient.session.prompt(buildPromptRequest({
+    sessionId,
+    agentName,
+    model: primaryModel,
+    prompt,
+  }))
+
+  const output = extractOutputText(unwrapResponseData(response))
+  if (!output) {
+    throw new Error("Primary model did not return collated review output")
+  }
+
+  return output
+}
+
+export function buildFailureWarning(input: BuildFailureWarningInput): string {
+  const { totalAdditional, failedCount } = input
+
+  if (totalAdditional > 0 && failedCount >= totalAdditional) {
+    return `⚠️ All ${totalAdditional} additional review models failed. Showing primary model review only.`
+  }
+
+  return `⚠️ ${failedCount} of ${totalAdditional} additional review models did not respond. Results based on ${totalAdditional - failedCount + 1} models (including primary).`
+}
+
+async function runSingleReviewer(input: {
+  agentName: string
+  model: string
+  prompt: string
+  client: ReviewClient
+}): Promise<ReviewResult> {
+  const { agentName, model, prompt, client } = input
+  const sessionId = await createEphemeralSession(client, `${agentName}-review-${sanitizeModelName(model)}`)
+
+  const response = await client.session.prompt(buildPromptRequest({
+    sessionId,
+    agentName,
+    model,
+    prompt,
+  }))
+
+  const output = extractOutputText(unwrapResponseData(response))
+  if (!output) {
+    throw new Error(`Reviewer ${model} returned no output`)
+  }
+
+  return {
+    model,
+    output,
+    success: true,
+  }
+}
+
+async function createEphemeralSession(client: ReviewClient, title: string): Promise<string> {
+  const response = await client.session.create({
+    title,
+    body: { title },
+  })
+
+  const sessionId = extractSessionId(unwrapResponseData(response))
+  if (!sessionId) {
+    throw new Error("Failed to create review session")
+  }
+
+  return sessionId
+}
+
+function buildPromptRequest(input: {
+  sessionId: string
+  agentName: string
+  model: string
+  prompt: string
+}): Record<string, unknown> {
+  const { sessionId, agentName, model, prompt } = input
+
+  return {
+    sessionID: sessionId,
+    path: { id: sessionId, sessionID: sessionId },
+    body: {
+      ...(agentName ? { agent: agentName } : {}),
+      model: toModelOverride(model),
+      parts: [{ type: "text", text: prompt }],
+    },
+  }
+}
+
+function buildCollationPrompt(input: {
+  primaryModel: string
+  primaryOutput: string
+  additionalResults: ReviewResult[]
+  originalContext: string
+}): string {
+  const successfulReviews = input.additionalResults
+    .filter((result) => result.success)
+    .map((result) => `## Additional reviewer: ${result.model}\n\n${result.output.trim()}`)
+
+  const failedReviews = input.additionalResults
+    .filter((result) => !result.success)
+    .map((result) => `- ${result.model}: ${result.error ?? "No response received."}`)
+
+  return [
+    "You are collating multiple AI review outputs into a single consolidated review.",
+    "Merge overlapping findings, deduplicate repeated points, and preserve unique issues.",
+    "Err toward inclusion: false negatives are intolerable, so keep plausible concerns unless clearly contradicted.",
+    "Match the format and tone of the input reviews rather than inventing a new structure.",
+    "",
+    "## Original review context",
+    input.originalContext.trim(),
+    "",
+    `## Primary reviewer: ${input.primaryModel}`,
+    input.primaryOutput.trim(),
+    "",
+    ...(successfulReviews.length > 0
+      ? ["## Additional reviewer outputs", "", successfulReviews.join("\n\n")]
+      : ["## Additional reviewer outputs", "", "No successful additional reviewer outputs were available."]),
+    "",
+    "## Failed additional reviewers",
+    failedReviews.length > 0 ? failedReviews.join("\n") : "- None",
+    "",
+    "Return only the final collated review.",
+  ].join("\n")
+}
+
+function toModelOverride(model: string): { providerID: string; modelID: string } {
+  const separatorIndex = model.indexOf("/")
+  if (separatorIndex <= 0 || separatorIndex === model.length - 1) {
+    throw new Error(`Model must be provider-qualified: ${model}`)
+  }
+
+  return {
+    providerID: model.slice(0, separatorIndex),
+    modelID: model.slice(separatorIndex + 1),
+  }
+}
+
+function unwrapResponseData(response: unknown): unknown {
+  if (!isRecord(response)) {
+    return response
+  }
+
+  return "data" in response ? response.data : response
+}
+
+function extractSessionId(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = value.id
+  return typeof id === "string" && id.length > 0 ? id : null
+}
+
+function extractOutputText(value: unknown): string {
+  return firstNonEmptyString([
+    readStringAtPath(value, ["output"]),
+    readStringAtPath(value, ["result", "output"]),
+    readStringAtPath(value, ["text"]),
+    readStringAtPath(value, ["message", "text"]),
+    readStringAtPath(value, ["lastAssistantMessage", "text"]),
+    extractTextFromParts(readUnknownAtPath(value, ["parts"])),
+    extractTextFromParts(readUnknownAtPath(value, ["message", "parts"])),
+    extractTextFromParts(readUnknownAtPath(value, ["lastAssistantMessage", "parts"])),
+    extractTextFromMessages(readUnknownAtPath(value, ["messages"])),
+  ])
+}
+
+function extractTextFromMessages(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return ""
+  }
+
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    const entry = value[index]
+    const text = firstNonEmptyString([
+      readStringAtPath(entry, ["text"]),
+      extractTextFromParts(readUnknownAtPath(entry, ["parts"])),
+      extractTextFromParts(readUnknownAtPath(entry, ["message", "parts"])),
+    ])
+    if (text) {
+      return text
+    }
+  }
+
+  return ""
+}
+
+function extractTextFromParts(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return ""
+  }
+
+  const text = value
+    .map((part) => {
+      if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") {
+        return ""
+      }
+      return part.text.trim()
+    })
+    .filter((part): part is string => part.length > 0)
+    .join("\n")
+
+  return text
+}
+
+function readUnknownAtPath(value: unknown, path: string[]): unknown {
+  let current: unknown = value
+  for (const segment of path) {
+    if (!isRecord(current) || !(segment in current)) {
+      return undefined
+    }
+    current = current[segment]
+  }
+  return current
+}
+
+function readStringAtPath(value: unknown, path: string[]): string {
+  const result = readUnknownAtPath(value, path)
+  return typeof result === "string" ? result.trim() : ""
+}
+
+function firstNonEmptyString(values: string[]): string {
+  return values.find((value) => value.length > 0) ?? ""
+}
+
+function sanitizeModelName(model: string): string {
+  return model.replace(/[^a-zA-Z0-9_-]+/g, "-")
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return typeof error === "string" ? error : "Unknown error"
+}

--- a/src/agents/review-resolver.test.ts
+++ b/src/agents/review-resolver.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "bun:test"
+import { resolveReviewers } from "./review-resolver"
+
+describe("resolveReviewers", () => {
+  it("(a) direct + Weft + two review_models => fan-out with config-order variants and batch size 3", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["anthropic/claude-sonnet-4", "openai/gpt-5"],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan.kind).toBe("fan-out")
+    if (plan.kind !== "fan-out") throw new Error("Expected fan-out")
+
+    expect(plan.variants.map((v) => v.key)).toEqual([
+      "weft-review-anthropic-claude-sonnet-4",
+      "weft-review-openai-gpt-5",
+    ])
+    expect(plan.batch).toEqual({ mode: "parallel", size: 3 })
+  })
+
+  it("(b) direct + Warp + one review_models => fan-out with only warp-* keys", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "warp",
+      agentOverrides: {
+        warp: {
+          model: "openai/gpt-4o",
+          review_models: ["anthropic/claude-sonnet-4"],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan.kind).toBe("fan-out")
+    if (plan.kind !== "fan-out") throw new Error("Expected fan-out")
+
+    expect(plan.variants).toHaveLength(1)
+    expect(plan.variants.every((v) => v.key.startsWith("warp-"))).toBe(true)
+    expect(plan.variants.map((v) => v.key)).toEqual(["warp-review-anthropic-claude-sonnet-4"])
+  })
+
+  it("(c) direct + Weft + disabledAgents includes weft => disabled", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["anthropic/claude-sonnet-4"],
+        },
+      },
+      disabledAgents: new Set(["weft"]),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan).toEqual({
+      kind: "disabled",
+      scope: "direct",
+      baseAgent: "weft",
+      reason: "agent-disabled",
+    })
+  })
+
+  it("(d) direct + Weft + empty review_models => primary-only (no-variants)", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: [],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan).toEqual({
+      kind: "primary-only",
+      scope: "direct",
+      baseAgent: "weft",
+      primary: { agentName: "weft", label: "Weft", model: "openai/gpt-4o" },
+      reason: "no-variants",
+    })
+  })
+
+  it("(e) direct + Weft + one review_model disabled => primary-only (all-variants-disabled)", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["opencode-go/x"],
+        },
+      },
+      disabledAgents: new Set(["weft-review-opencode-go-x"]),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan).toEqual({
+      kind: "primary-only",
+      scope: "direct",
+      baseAgent: "weft",
+      primary: { agentName: "weft", label: "Weft", model: "openai/gpt-4o" },
+      reason: "all-variants-disabled",
+    })
+  })
+
+  it("(f) review_models entry matching primary model is filtered; sole entry => primary-only (no-variants)", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["openai/gpt-4o"],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan).toEqual({
+      kind: "primary-only",
+      scope: "direct",
+      baseAgent: "weft",
+      primary: { agentName: "weft", label: "Weft", model: "openai/gpt-4o" },
+      reason: "no-variants",
+    })
+  })
+
+  it("filters review_models against resolved primaryModel when override model is absent", () => {
+    const plan = resolveReviewers({
+      scope: "post-execution",
+      baseAgent: "warp",
+      agentOverrides: {
+        warp: {
+          review_models: ["openai/gpt-5"],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-5",
+    })
+
+    expect(plan).toEqual({
+      kind: "primary-only",
+      scope: "post-execution",
+      baseAgent: "warp",
+      primary: { agentName: "warp", label: "Warp", model: "openai/gpt-5" },
+      reason: "no-variants",
+    })
+  })
+
+  it("filters both override model and primary model and keeps only distinct variants", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["openai/gpt-4o", "openai/gpt-5", "anthropic/claude-sonnet-4"],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-5",
+    })
+
+    expect(plan.kind).toBe("fan-out")
+    if (plan.kind !== "fan-out") throw new Error("Expected fan-out")
+    expect(plan.variants.map((v) => v.model)).toEqual(["anthropic/claude-sonnet-4"])
+  })
+
+  it("(g) Weft plan never contains warp-* variants even when agents.warp.review_models is set", () => {
+    const plan = resolveReviewers({
+      scope: "direct",
+      baseAgent: "weft",
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["anthropic/claude-sonnet-4"],
+        },
+        warp: {
+          model: "openai/gpt-4o",
+          review_models: ["google/gemini-2.5-pro"],
+        },
+      },
+      disabledAgents: new Set(),
+      primaryModel: "openai/gpt-4o",
+    })
+
+    expect(plan.kind).toBe("fan-out")
+    if (plan.kind !== "fan-out") throw new Error("Expected fan-out")
+
+    expect(plan.variants.map((v) => v.key)).toEqual(["weft-review-anthropic-claude-sonnet-4"])
+    expect(plan.variants.some((v) => v.key.startsWith("warp-"))).toBe(false)
+  })
+
+  it("(h) post-execution and direct are structurally identical for same inputs except scope", () => {
+    const shared = {
+      baseAgent: "weft" as const,
+      agentOverrides: {
+        weft: {
+          model: "openai/gpt-4o",
+          review_models: ["anthropic/claude-sonnet-4", "openai/gpt-5"],
+        },
+      },
+      disabledAgents: new Set<string>(),
+      primaryModel: "openai/gpt-4o",
+    }
+
+    const direct = resolveReviewers({ ...shared, scope: "direct" })
+    const postExecution = resolveReviewers({ ...shared, scope: "post-execution" })
+
+    expect(direct.scope).toBe("direct")
+    expect(postExecution.scope).toBe("post-execution")
+
+    expect({ ...direct, scope: "same" }).toEqual({ ...postExecution, scope: "same" })
+  })
+})

--- a/src/agents/review-resolver.ts
+++ b/src/agents/review-resolver.ts
@@ -1,0 +1,105 @@
+import type { AgentOverrideConfig } from "../config/schema"
+import {
+  buildReviewModelVariants,
+  reviewVariantsFor,
+  type ReviewModelVariant,
+} from "./review-model-variants"
+
+export type ReviewBaseAgent = "weft" | "warp"
+
+type ReviewScope = "direct" | "post-execution"
+
+type ReviewerPrimary = {
+  agentName: ReviewBaseAgent
+  label: "Weft" | "Warp"
+  model: string
+}
+
+export type ReviewerPlan =
+  | {
+    kind: "fan-out"
+    scope: ReviewScope
+    baseAgent: ReviewBaseAgent
+    primary: ReviewerPrimary
+    variants: ReviewModelVariant[]
+    batch: { mode: "parallel", size: number }
+  }
+  | {
+    kind: "primary-only"
+    scope: ReviewScope
+    baseAgent: ReviewBaseAgent
+    primary: ReviewerPrimary
+    reason: "no-variants" | "all-variants-disabled"
+  }
+  | {
+    kind: "disabled"
+    scope: ReviewScope
+    baseAgent: ReviewBaseAgent
+    reason: "agent-disabled"
+  }
+
+export function resolveReviewers(input: {
+  scope: ReviewScope
+  baseAgent: ReviewBaseAgent
+  agentOverrides: Record<string, AgentOverrideConfig> | undefined
+  disabledAgents: Set<string>
+  primaryModel: string
+}): ReviewerPlan {
+  const { scope, baseAgent, agentOverrides, disabledAgents, primaryModel } = input
+
+  if (disabledAgents.has(baseAgent)) {
+    return {
+      kind: "disabled",
+      scope,
+      baseAgent,
+      reason: "agent-disabled",
+    }
+  }
+
+  const overrideModel = agentOverrides?.[baseAgent]?.model
+  const allVariants = reviewVariantsFor(
+    buildReviewModelVariants(agentOverrides, disabledAgents),
+    baseAgent,
+  ).filter((variant) => variant.model !== primaryModel && variant.model !== overrideModel)
+  const rawConfigured = (agentOverrides?.[baseAgent]?.review_models ?? [])
+    .filter((model) => model !== overrideModel)
+    .filter((model) => model !== primaryModel)
+
+  const primary = {
+    agentName: baseAgent,
+    label: baseAgent === "weft" ? "Weft" : "Warp",
+    model: primaryModel,
+  } as const
+
+  if (rawConfigured.length === 0) {
+    return {
+      kind: "primary-only",
+      scope,
+      baseAgent,
+      primary,
+      reason: "no-variants",
+    }
+  }
+
+  if (rawConfigured.length > 0 && allVariants.length === 0) {
+    return {
+      kind: "primary-only",
+      scope,
+      baseAgent,
+      primary,
+      reason: "all-variants-disabled",
+    }
+  }
+
+  return {
+    kind: "fan-out",
+    scope,
+    baseAgent,
+    primary,
+    variants: allVariants,
+    batch: {
+      mode: "parallel",
+      size: 1 + allVariants.length,
+    },
+  }
+}

--- a/src/agents/tapestry/index.test.ts
+++ b/src/agents/tapestry/index.test.ts
@@ -58,13 +58,15 @@ describe("createTapestryAgent", () => {
     expect(prompt).toContain("</PostExecutionReview>")
   })
 
-  it("PostExecutionReview invokes Weft and Warp directly", () => {
+  it("PostExecutionReview references runtime-owned Weft/Warp review", () => {
     const config = createTapestryAgent("claude-sonnet-4")
     const prompt = config.prompt as string
     const reviewSection = prompt.slice(prompt.indexOf("<PostExecutionReview>"), prompt.indexOf("</PostExecutionReview>"))
     expect(reviewSection).toContain("Weft")
     expect(reviewSection).toContain("Warp")
-    expect(reviewSection).toContain("Task tool")
+    expect(reviewSection).toContain("runtime reviewer fan-out runs automatically")
+    expect(reviewSection).toContain("do not delegate terminal reviewers via Task tool")
+    expect(reviewSection).toContain("the Weave runtime spawns the configured variants and collates results automatically")
   })
 
   it("PostExecutionReview reports findings without fixing them", () => {
@@ -138,6 +140,7 @@ describe("createTapestryAgent", () => {
   it("createTapestryAgentWithOptions omits CategoryRouting section when no categories provided", () => {
     const config = createTapestryAgentWithOptions("claude-sonnet-4")
     expect(config.prompt).not.toContain("<CategoryRouting>")
+    expect(config.prompt).toContain("the Weave runtime spawns the configured variants and collates results automatically")
   })
 
   it("createTapestryAgentWithOptions includes manual-only CategoryRouting when categories have no patterns", () => {

--- a/src/agents/tapestry/index.ts
+++ b/src/agents/tapestry/index.ts
@@ -19,13 +19,6 @@ export function createTapestryAgentWithOptions(
   categories?: CategoriesConfig,
   reviewModelVariants?: ReviewModelVariant[],
 ): AgentConfig {
-  const hasDisabled = disabledAgents && disabledAgents.size > 0
-  const needsCustomPrompt = hasDisabled || continuation || categories || (reviewModelVariants && reviewModelVariants.length > 0)
-
-  if (!needsCustomPrompt) {
-    return { ...TAPESTRY_DEFAULTS, tools: { ...TAPESTRY_DEFAULTS.tools }, model, mode: "primary" }
-  }
-
   return {
     ...TAPESTRY_DEFAULTS,
     tools: { ...TAPESTRY_DEFAULTS.tools },

--- a/src/agents/tapestry/index.ts
+++ b/src/agents/tapestry/index.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { ResolvedContinuationConfig } from "../../config/continuation"
 import type { CategoriesConfig } from "../../config/schema"
 import type { AgentFactory } from "../types"
+import type { ReviewModelVariant } from "../review-model-variants"
 import { TAPESTRY_DEFAULTS } from "./default"
 import { composeTapestryPrompt } from "./prompt-composer"
 
@@ -16,9 +17,10 @@ export function createTapestryAgentWithOptions(
   disabledAgents?: Set<string>,
   continuation?: ResolvedContinuationConfig,
   categories?: CategoriesConfig,
+  reviewModelVariants?: ReviewModelVariant[],
 ): AgentConfig {
   const hasDisabled = disabledAgents && disabledAgents.size > 0
-  const needsCustomPrompt = hasDisabled || continuation || categories
+  const needsCustomPrompt = hasDisabled || continuation || categories || (reviewModelVariants && reviewModelVariants.length > 0)
 
   if (!needsCustomPrompt) {
     return { ...TAPESTRY_DEFAULTS, tools: { ...TAPESTRY_DEFAULTS.tools }, model, mode: "primary" }
@@ -27,7 +29,7 @@ export function createTapestryAgentWithOptions(
   return {
     ...TAPESTRY_DEFAULTS,
     tools: { ...TAPESTRY_DEFAULTS.tools },
-    prompt: composeTapestryPrompt({ disabledAgents, continuation, categories }),
+    prompt: composeTapestryPrompt({ disabledAgents, continuation, categories, reviewModelVariants }),
     model,
     mode: "primary",
   }

--- a/src/agents/tapestry/prompt-composer.test.ts
+++ b/src/agents/tapestry/prompt-composer.test.ts
@@ -102,6 +102,21 @@ describe("buildTapestryPostExecutionReviewSection", () => {
     expect(section).toContain("Warp")
   })
 
+  it("includes visible review model variants as task delegates", () => {
+    const section = buildTapestryPostExecutionReviewSection(new Set(), [
+      {
+        baseAgent: "weft" as const,
+        key: "weft-review-opencode-go-kimi-k2-6",
+        model: "opencode-go/kimi-k2.6",
+        label: "weft @ opencode-go/kimi-k2.6",
+      },
+    ])
+
+    expect(section).toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
+    expect(section).toContain("visible additional Weft code-quality review using opencode-go/kimi-k2.6")
+    expect(section).toContain("weft-review-* variants are code-quality Weft reviewers only")
+  })
+
   it("omits review delegation when both disabled", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set(["weft", "warp"]))
     expect(section).not.toContain("Delegate to")

--- a/src/agents/tapestry/prompt-composer.test.ts
+++ b/src/agents/tapestry/prompt-composer.test.ts
@@ -59,13 +59,14 @@ describe("composeTapestryPrompt", () => {
     expect(reviewSection).toContain("Warp")
   })
 
-  it("PostExecutionReview mentions Task tool by default", () => {
+  it("PostExecutionReview mentions runtime-owned reviewer fan-out by default", () => {
     const prompt = composeTapestryPrompt()
     const reviewSection = prompt.slice(
       prompt.indexOf("<PostExecutionReview>"),
       prompt.indexOf("</PostExecutionReview>"),
     )
-    expect(reviewSection).toContain("Task tool")
+    expect(reviewSection).toContain("runtime reviewer fan-out runs automatically")
+    expect(reviewSection).toContain("do not delegate terminal reviewers via Task tool")
   })
 })
 
@@ -87,22 +88,24 @@ describe("buildTapestryPostExecutionReviewSection", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set())
     expect(section).toContain("Weft")
     expect(section).toContain("Warp")
-    expect(section).toContain("Task tool")
+    expect(section).toContain("runtime reviewer fan-out runs automatically")
   })
 
   it("includes only Weft when warp disabled", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set(["warp"]))
-    expect(section).toContain("Weft")
-    expect(section).not.toContain("Warp")
+    expect(section).toContain("Summarize Weft's findings")
+    expect(section).not.toContain("Summarize Warp's findings")
+    expect(section).toContain("Do not issue terminal reviewer Task calls")
   })
 
   it("includes only Warp when weft disabled", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set(["weft"]))
-    expect(section).not.toContain("Weft")
-    expect(section).toContain("Warp")
+    expect(section).toContain("Summarize Warp's findings")
+    expect(section).not.toContain("Summarize Weft's findings")
+    expect(section).toContain("Do not issue terminal reviewer Task calls")
   })
 
-  it("includes visible review model variants as task delegates", () => {
+  it("does not enumerate visible review model variants as task delegates", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set(), [
       {
         baseAgent: "weft" as const,
@@ -112,17 +115,16 @@ describe("buildTapestryPostExecutionReviewSection", () => {
       },
     ])
 
-    expect(section).toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
-    expect(section).toContain("visible additional Weft code-quality review using opencode-go/kimi-k2.6")
-    expect(section).toContain("weft-review-* variants are code-quality Weft reviewers only")
-    expect(section).toContain("issue ALL validator Task calls above in the same assistant turn")
-    expect(section).toContain("do not run only the first reviewer and stop")
+    expect(section).not.toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
+    expect(section).toContain("the Weave runtime spawns the configured variants and collates results automatically")
+    expect(section).toContain("do not issue extra Task calls for them")
+    expect(section).toContain("Do not issue terminal reviewer Task calls")
   })
 
   it("omits review delegation when both disabled", () => {
     const section = buildTapestryPostExecutionReviewSection(new Set(["weft", "warp"]))
     expect(section).not.toContain("Delegate to")
-    expect(section).not.toContain("Task tool")
+    expect(section).not.toContain("do not delegate terminal reviewers via Task tool")
     expect(section).toContain("Report the summary")
   })
 

--- a/src/agents/tapestry/prompt-composer.test.ts
+++ b/src/agents/tapestry/prompt-composer.test.ts
@@ -115,6 +115,8 @@ describe("buildTapestryPostExecutionReviewSection", () => {
     expect(section).toContain('subagent_type "weft-review-opencode-go-kimi-k2-6"')
     expect(section).toContain("visible additional Weft code-quality review using opencode-go/kimi-k2.6")
     expect(section).toContain("weft-review-* variants are code-quality Weft reviewers only")
+    expect(section).toContain("issue ALL validator Task calls above in the same assistant turn")
+    expect(section).toContain("do not run only the first reviewer and stop")
   })
 
   it("omits review delegation when both disabled", () => {

--- a/src/agents/tapestry/prompt-composer.ts
+++ b/src/agents/tapestry/prompt-composer.ts
@@ -10,7 +10,9 @@ import { isAgentEnabled } from "../prompt-utils"
 import type { ResolvedContinuationConfig } from "../../config/continuation"
 import type { CategoriesConfig } from "../../config/schema"
 import type { ReviewModelVariant } from "../review-model-variants"
-import { reviewVariantsFor } from "../review-model-variants"
+
+const REVIEW_MODELS_AUTOMATION_ADVISORY = "When `review_models` are configured for Weft or Warp, the Weave runtime spawns the configured variants and collates results automatically — do not issue extra Task calls for them."
+const REVIEWERS_RUNTIME_OWNED_ADVISORY = "When Weft and/or Warp reviewers are enabled, runtime reviewer fan-out runs automatically after plan completion — do not delegate terminal reviewers via Task tool."
 
 export interface TapestryPromptOptions {
   /** Set of disabled agent names (lowercase config keys) */
@@ -19,7 +21,7 @@ export interface TapestryPromptOptions {
   continuation?: ResolvedContinuationConfig
   /** Categories config for dynamic category routing section */
   categories?: CategoriesConfig
-  /** Visible review model variants generated from agents.weft/warp.review_models */
+  /** Compatibility input: variant enumeration is runtime-owned; the composer emits only advisory guidance. */
   reviewModelVariants?: ReviewModelVariant[]
 }
 
@@ -355,12 +357,11 @@ export function buildTapestryPostExecutionReviewSection(
   disabled: Set<string>,
   reviewModelVariants: ReviewModelVariant[] = [],
 ): string {
+  void reviewModelVariants
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
-  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
-  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
-  if (!hasWeft && !hasWarp && weftVariants.length === 0 && warpVariants.length === 0) {
+  if (!hasWeft && !hasWarp) {
     return `<PostExecutionReview>
 This section applies only after ALL plan tasks are already checked off.
 
@@ -375,33 +376,9 @@ After ALL plan tasks are checked off:
 </PostExecutionReview>`
   }
 
-  const reviewerLines: string[] = []
-  if (hasWeft) {
-    reviewerLines.push(`   - Delegate to Weft: subagent_type "weft" — reviews code quality`)
-  }
-  for (const variant of weftVariants) {
-    reviewerLines.push(`   - Delegate to ${variant.label}: subagent_type "${variant.key}" — visible additional Weft code-quality review using ${variant.model}; NOT a Warp/security audit`)
-  }
-  if (hasWarp) {
-    reviewerLines.push(
-      `   - Delegate to Warp: subagent_type "warp" — audits security (self-triages; fast-exits with APPROVE if no security-relevant changes)`,
-    )
-  }
-  for (const variant of warpVariants) {
-    reviewerLines.push(`   - Delegate to ${variant.label}: subagent_type "${variant.key}" — visible additional Warp security review using ${variant.model}`)
-  }
-  const boundaryLine = weftVariants.length > 0
-    ? `   - Boundary rule: weft-review-* variants are code-quality Weft reviewers only. Never label or use them as Warp/security audits; security audits must use subagent_type "warp" or configured warp-review-* variants.`
-    : null
-  const parallelLine = reviewerLines.length > 1
-    ? `   - Parallel rule: issue ALL validator Task calls above in the same assistant turn before waiting for any result; do not run only the first reviewer and stop.`
-    : null
-
   const reviewerNames = [
     hasWeft && "Weft",
-    ...weftVariants.map((variant) => variant.label),
     hasWarp && "Warp",
-    ...warpVariants.map((variant) => variant.label),
   ].filter(Boolean).join(" and ")
 
   return `<PostExecutionReview>
@@ -414,10 +391,11 @@ When all plan tasks are checked off:
 1. Identify all changed files:
     - If a **Start SHA** was provided in the session context, run \`git diff --name-only <start-sha>..HEAD\` to get the complete list of changed files (this captures all changes including intermediate commits)
    - If no Start SHA is available (non-git workspace), use the plan's \`**Files**:\` fields as the review scope
-2. Run the required terminal validation workflow using the Task tool:
-${reviewerLines.join("\n")}
-   - Include the list of changed files in your prompt to each terminal validator
-${parallelLine ? parallelLine + "\n" : ""}${boundaryLine ? boundaryLine + "\n" : ""}3. Report the terminal results to the user:
+ 2. Runtime-owned terminal review behavior:
+    - ${REVIEWERS_RUNTIME_OWNED_ADVISORY}
+    - ${REVIEW_MODELS_AUTOMATION_ADVISORY}
+    - Do not issue terminal reviewer Task calls (including Weft/Warp and any review-model variant subagent_type values).
+3. Report the terminal results to the user:
    - Summarize ${reviewerNames}'s findings (APPROVE or REJECT with details)
    - If either validator REJECTS, present the blocking issues to the user for decision — do NOT attempt to fix them yourself
    - Tapestry follows the plan; terminal findings require user approval before any further changes
@@ -472,6 +450,7 @@ export function composeTapestryPrompt(options: TapestryPromptOptions = {}): stri
     continuationHint,
     buildTapestryVerificationSection(),
     buildTapestryErrorHandlingSection(),
+    // Backward-compatible parameter passthrough for existing call sites.
     buildTapestryPostExecutionReviewSection(disabled, options.reviewModelVariants ?? []),
     buildTapestryExecutionSection(),
     buildTapestryStyleSection(),

--- a/src/agents/tapestry/prompt-composer.ts
+++ b/src/agents/tapestry/prompt-composer.ts
@@ -393,6 +393,9 @@ After ALL plan tasks are checked off:
   const boundaryLine = weftVariants.length > 0
     ? `   - Boundary rule: weft-review-* variants are code-quality Weft reviewers only. Never label or use them as Warp/security audits; security audits must use subagent_type "warp" or configured warp-review-* variants.`
     : null
+  const parallelLine = reviewerLines.length > 1
+    ? `   - Parallel rule: issue ALL validator Task calls above in the same assistant turn before waiting for any result; do not run only the first reviewer and stop.`
+    : null
 
   const reviewerNames = [
     hasWeft && "Weft",
@@ -414,7 +417,7 @@ When all plan tasks are checked off:
 2. Run the required terminal validation workflow using the Task tool:
 ${reviewerLines.join("\n")}
    - Include the list of changed files in your prompt to each terminal validator
-${boundaryLine ? boundaryLine + "\n" : ""}3. Report the terminal results to the user:
+${parallelLine ? parallelLine + "\n" : ""}${boundaryLine ? boundaryLine + "\n" : ""}3. Report the terminal results to the user:
    - Summarize ${reviewerNames}'s findings (APPROVE or REJECT with details)
    - If either validator REJECTS, present the blocking issues to the user for decision — do NOT attempt to fix them yourself
    - Tapestry follows the plan; terminal findings require user approval before any further changes

--- a/src/agents/tapestry/prompt-composer.ts
+++ b/src/agents/tapestry/prompt-composer.ts
@@ -9,6 +9,8 @@
 import { isAgentEnabled } from "../prompt-utils"
 import type { ResolvedContinuationConfig } from "../../config/continuation"
 import type { CategoriesConfig } from "../../config/schema"
+import type { ReviewModelVariant } from "../review-model-variants"
+import { reviewVariantsFor } from "../review-model-variants"
 
 export interface TapestryPromptOptions {
   /** Set of disabled agent names (lowercase config keys) */
@@ -17,6 +19,8 @@ export interface TapestryPromptOptions {
   continuation?: ResolvedContinuationConfig
   /** Categories config for dynamic category routing section */
   categories?: CategoriesConfig
+  /** Visible review model variants generated from agents.weft/warp.review_models */
+  reviewModelVariants?: ReviewModelVariant[]
 }
 
 export function buildTapestryRoleSection(): string {
@@ -347,11 +351,16 @@ After Shuttle completes a task — BEFORE marking \`- [ ]\` → \`- [x]\`:
 </Verification>`
 }
 
-export function buildTapestryPostExecutionReviewSection(disabled: Set<string>): string {
+export function buildTapestryPostExecutionReviewSection(
+  disabled: Set<string>,
+  reviewModelVariants: ReviewModelVariant[] = [],
+): string {
   const hasWeft = isAgentEnabled("weft", disabled)
   const hasWarp = isAgentEnabled("warp", disabled)
+  const weftVariants = reviewVariantsFor(reviewModelVariants, "weft")
+  const warpVariants = reviewVariantsFor(reviewModelVariants, "warp")
 
-  if (!hasWeft && !hasWarp) {
+  if (!hasWeft && !hasWarp && weftVariants.length === 0 && warpVariants.length === 0) {
     return `<PostExecutionReview>
 This section applies only after ALL plan tasks are already checked off.
 
@@ -370,13 +379,27 @@ After ALL plan tasks are checked off:
   if (hasWeft) {
     reviewerLines.push(`   - Delegate to Weft: subagent_type "weft" — reviews code quality`)
   }
+  for (const variant of weftVariants) {
+    reviewerLines.push(`   - Delegate to ${variant.label}: subagent_type "${variant.key}" — visible additional Weft code-quality review using ${variant.model}; NOT a Warp/security audit`)
+  }
   if (hasWarp) {
     reviewerLines.push(
       `   - Delegate to Warp: subagent_type "warp" — audits security (self-triages; fast-exits with APPROVE if no security-relevant changes)`,
     )
   }
+  for (const variant of warpVariants) {
+    reviewerLines.push(`   - Delegate to ${variant.label}: subagent_type "${variant.key}" — visible additional Warp security review using ${variant.model}`)
+  }
+  const boundaryLine = weftVariants.length > 0
+    ? `   - Boundary rule: weft-review-* variants are code-quality Weft reviewers only. Never label or use them as Warp/security audits; security audits must use subagent_type "warp" or configured warp-review-* variants.`
+    : null
 
-  const reviewerNames = [hasWeft && "Weft", hasWarp && "Warp"].filter(Boolean).join(" and ")
+  const reviewerNames = [
+    hasWeft && "Weft",
+    ...weftVariants.map((variant) => variant.label),
+    hasWarp && "Warp",
+    ...warpVariants.map((variant) => variant.label),
+  ].filter(Boolean).join(" and ")
 
   return `<PostExecutionReview>
 This section applies only when no unchecked plan tasks remain.
@@ -391,7 +414,7 @@ When all plan tasks are checked off:
 2. Run the required terminal validation workflow using the Task tool:
 ${reviewerLines.join("\n")}
    - Include the list of changed files in your prompt to each terminal validator
-3. Report the terminal results to the user:
+${boundaryLine ? boundaryLine + "\n" : ""}3. Report the terminal results to the user:
    - Summarize ${reviewerNames}'s findings (APPROVE or REJECT with details)
    - If either validator REJECTS, present the blocking issues to the user for decision — do NOT attempt to fix them yourself
    - Tapestry follows the plan; terminal findings require user approval before any further changes
@@ -446,7 +469,7 @@ export function composeTapestryPrompt(options: TapestryPromptOptions = {}): stri
     continuationHint,
     buildTapestryVerificationSection(),
     buildTapestryErrorHandlingSection(),
-    buildTapestryPostExecutionReviewSection(disabled),
+    buildTapestryPostExecutionReviewSection(disabled, options.reviewModelVariants ?? []),
     buildTapestryExecutionSection(),
     buildTapestryStyleSection(),
   ].filter((section): section is string => Boolean(section))

--- a/src/application/orchestration/session-runtime.ts
+++ b/src/application/orchestration/session-runtime.ts
@@ -13,10 +13,12 @@ export type {
 } from "../policy/runtime-policy"
 import type { CreatedHooks } from "../../hooks/create-hooks"
 import type { PluginContext } from "../../plugin/types"
+import type { ReviewerPlan } from "../../agents/review-resolver"
 import { createCompactionTodoPreserver } from "../../hooks/compaction-todo-preserver"
 import { createTodoContinuationEnforcer } from "../../hooks/todo-continuation-enforcer"
 import { createPolicyEngine } from "../policy/policy-engine"
 import { createAutoPauseChatPolicy, createCommandChatPolicy, createTodoFinalizationChatPolicy } from "../policy/chat-policy"
+import { createDirectReviewerFanOutSessionPolicy } from "../policy/direct-reviewer-fanout-session-policy"
 import { createHookBackedSessionPolicy } from "../policy/session-policy"
 import { createTodoDescriptionToolDefinitionPolicy } from "../policy/tool-definition-policy"
 import { createHookBackedToolPolicy } from "../policy/tool-policy"
@@ -24,6 +26,9 @@ import { createHookBackedToolPolicy } from "../policy/tool-policy"
 export function createRuntimeLifecyclePolicySurface(args: {
   hooks: CreatedHooks
   client?: PluginContext["client"]
+  reviewerResolver?: {
+    forBaseAgent(baseAgent: "weft" | "warp", scope: "direct" | "post-execution"): ReviewerPlan
+  }
 }
 ): import("../policy/runtime-policy").RuntimeLifecyclePolicySurface {
   const compactionPreserver =
@@ -38,10 +43,17 @@ export function createRuntimeLifecyclePolicySurface(args: {
         })
       : null
 
+  const directReviewerFanOutPolicy = args.reviewerResolver
+    ? createDirectReviewerFanOutSessionPolicy({ reviewerResolver: args.reviewerResolver })
+    : null
+
   return createPolicyEngine({
     chatPolicies: [createCommandChatPolicy(), createAutoPauseChatPolicy(), createTodoFinalizationChatPolicy(todoContinuationEnforcer)],
     toolPolicies: [createHookBackedToolPolicy()],
     toolDefinitionPolicies: [createTodoDescriptionToolDefinitionPolicy()],
-    sessionPolicies: [createHookBackedSessionPolicy({ todoContinuationEnforcer, compactionPreserver })],
+    sessionPolicies: [
+      createHookBackedSessionPolicy({ reviewerResolver: args.reviewerResolver, todoContinuationEnforcer, compactionPreserver }),
+      ...(directReviewerFanOutPolicy ? [directReviewerFanOutPolicy] : []),
+    ],
   })
 }

--- a/src/application/policy/context-window-session-policy.ts
+++ b/src/application/policy/context-window-session-policy.ts
@@ -12,6 +12,13 @@ export interface ContextWindowSessionPolicy {
 export function createContextWindowSessionPolicy(): ContextWindowSessionPolicy {
   return {
     onAssistantMessage(input) {
+      // Reserved for downstream collation policies; context-window policy remains token-based.
+      void input.directory
+      void input.foregroundAgent
+      void input.assistantText
+      void input.originalPromptText
+      void input.messageId
+
       if (!input.hooks.contextWindowThresholds || input.inputTokens <= 0) {
         return createPolicyResult<RuntimeEffect>()
       }

--- a/src/application/policy/direct-reviewer-fanout-session-policy.test.ts
+++ b/src/application/policy/direct-reviewer-fanout-session-policy.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it } from "bun:test"
+import { createDirectReviewerFanOutSessionPolicy } from "./direct-reviewer-fanout-session-policy"
+import type { ReviewerPlan } from "../../agents/review-resolver"
+
+function makeFanOutPlan(baseAgent: "weft" | "warp"): ReviewerPlan {
+  return {
+    kind: "fan-out",
+    scope: "direct",
+    baseAgent,
+    primary: {
+      agentName: baseAgent,
+      label: baseAgent === "weft" ? "Weft" : "Warp",
+      model: "primary-model",
+    },
+    variants: [
+      {
+        baseAgent,
+        key: `${baseAgent}-v1`,
+        model: "variant-model",
+        label: `${baseAgent} @ variant-model`,
+      },
+    ],
+    batch: { mode: "parallel", size: 2 },
+  }
+}
+
+describe("createDirectReviewerFanOutSessionPolicy", () => {
+  it("emits fan-out effect with original prompt and captured primary output", async () => {
+    const plan = makeFanOutPlan("weft")
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => plan,
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-1",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "assistant verdict",
+      originalPromptText: "user original request",
+      messageId: "msg-1",
+    })
+
+    expect(result.effects).toHaveLength(1)
+    expect(result.effects[0]).toMatchObject({
+      type: "runReviewerFanOut",
+      sessionId: "sess-1",
+      plan,
+      capturedPrimaryOutput: "assistant verdict",
+      promptText: "user original request",
+      originalContext: "user original request",
+      idempotencyKey: "sess-1:msg-1",
+      delivery: { kind: "injectPromptAsync" },
+    })
+    expect((result.effects[0] as { promptText: string }).promptText).not.toBe("assistant verdict")
+  })
+
+  it("emits zero effects for primary-only direct plan", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => ({
+          kind: "primary-only",
+          scope: "direct",
+          baseAgent: "warp",
+          primary: { agentName: "warp", label: "Warp", model: "model" },
+          reason: "no-variants",
+        }),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-2",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "warp",
+      assistantText: "assistant verdict",
+      originalPromptText: "user original request",
+      messageId: "msg-2",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("emits zero effects for disabled plan", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => ({
+          kind: "disabled",
+          scope: "direct",
+          baseAgent: "weft",
+          reason: "agent-disabled",
+        }),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-3",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "assistant verdict",
+      originalPromptText: "user original request",
+      messageId: "msg-3",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("emits zero effects when originalPromptText is missing", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-4",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "assistant verdict",
+      messageId: "msg-4",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("still emits fan-out when assistant text includes reviewer fan-out sentinel", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-5",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "result <!-- weave:reviewer-fanout --> message",
+      originalPromptText: "user original request",
+      respondingToTrustedInjectedPromptKind: "generic",
+      messageId: "msg-5",
+    })
+
+    expect(result.effects).toHaveLength(1)
+    expect(result.effects[0]).toMatchObject({
+      type: "runReviewerFanOut",
+      sessionId: "sess-5",
+      idempotencyKey: "sess-5:msg-5",
+    })
+  })
+
+  it("emits zero effects when responding to trusted reviewer-fanout injected prompt", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-8",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "assistant verdict",
+      originalPromptText: "runtime injected prompt",
+      respondingToTrustedInjectedPromptKind: "reviewer-fanout",
+      messageId: "msg-8",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("still emits fan-out when responding to trusted generic injected prompt", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-9",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "assistant verdict",
+      originalPromptText: "runtime injected generic prompt",
+      respondingToTrustedInjectedPromptKind: "generic",
+      messageId: "msg-9",
+    })
+
+    expect(result.effects).toHaveLength(1)
+    expect(result.effects[0]).toMatchObject({
+      type: "runReviewerFanOut",
+      sessionId: "sess-9",
+      idempotencyKey: "sess-9:msg-9",
+    })
+  })
+
+  it("emits zero effects when messageId is missing", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-7",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "weft",
+      assistantText: "assistant verdict",
+      originalPromptText: "user original request",
+      messageId: "",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("emits zero effects for unknown foreground agent", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-6",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "thread",
+      assistantText: "assistant verdict",
+      originalPromptText: "user original request",
+      messageId: "msg-6",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("falls back to explicit @weft mention when foreground agent is loom", async () => {
+    const plan = makeFanOutPlan("weft")
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => plan,
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-10",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "loom",
+      assistantText: "assistant verdict",
+      originalPromptText: "Puedes probar con @weft el ultimo commit?",
+      messageId: "msg-10",
+    })
+
+    expect(result.effects).toHaveLength(1)
+    expect(result.effects[0]).toMatchObject({
+      type: "runReviewerFanOut",
+      sessionId: "sess-10",
+      plan,
+      idempotencyKey: "sess-10:msg-10",
+    })
+  })
+
+  it("falls back to explicit @warp mention when foreground agent is loom", async () => {
+    const plan = makeFanOutPlan("warp")
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => plan,
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-11",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "loom",
+      assistantText: "assistant verdict",
+      originalPromptText: "Puedes probar con @warp el ultimo commit?",
+      messageId: "msg-11",
+    })
+
+    expect(result.effects).toHaveLength(1)
+    expect(result.effects[0]).toMatchObject({
+      type: "runReviewerFanOut",
+      sessionId: "sess-11",
+      plan,
+      idempotencyKey: "sess-11:msg-11",
+    })
+  })
+
+  it("does not treat natural-language weft text as explicit fallback when foreground agent is loom", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-12",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "loom",
+      assistantText: "assistant verdict",
+      originalPromptText: "Puedes probar con weft el ultimo commit?",
+      messageId: "msg-12",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+
+  it("does not fallback when both @weft and @warp mentions are present and foreground agent is not explicit reviewer", async () => {
+    const policy = createDirectReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent: () => makeFanOutPlan("weft"),
+      },
+    })
+
+    const result = await policy.onAssistantMessage({
+      directory: "repo",
+      sessionId: "sess-13",
+      hooks: {
+        contextWindowThresholds: null,
+        rulesInjectorEnabled: false,
+        patternMdOnlyEnabled: false,
+        verificationReminderEnabled: false,
+        todoDescriptionOverrideEnabled: false,
+        todoContinuationEnforcerEnabled: false,
+      },
+      inputTokens: 100,
+      foregroundAgent: "loom",
+      assistantText: "assistant verdict",
+      originalPromptText: "Compare @weft and @warp on this commit",
+      messageId: "msg-13",
+    })
+
+    expect(result.effects).toEqual([])
+  })
+})

--- a/src/application/policy/direct-reviewer-fanout-session-policy.ts
+++ b/src/application/policy/direct-reviewer-fanout-session-policy.ts
@@ -1,0 +1,115 @@
+import { createPolicyResult, type PolicyResult } from "../../domain/policy/policy-result"
+import type { ReviewerPlan } from "../../agents/review-resolver"
+import type { RuntimeEffect } from "../../runtime/opencode/effects"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
+import type {
+  RuntimeAssistantMessageInput,
+  RuntimeBeforeCompactionInput,
+  RuntimeCompactionInput,
+  RuntimeSessionDeletedInput,
+  RuntimeSessionIdleInput,
+} from "./runtime-policy"
+import type { SessionPolicy } from "./session-policy"
+
+export function createDirectReviewerFanOutSessionPolicy(args: {
+  reviewerResolver: {
+    forBaseAgent(baseAgent: "weft" | "warp", scope: "direct" | "post-execution"): ReviewerPlan
+  }
+}): SessionPolicy {
+  return {
+    onAssistantMessage(input: RuntimeAssistantMessageInput): PolicyResult<RuntimeEffect> {
+      if (!input.assistantText) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      if (!input.originalPromptText) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      if (input.respondingToTrustedInjectedPromptKind === "reviewer-fanout") {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      const resolvedBaseAgent = resolveDirectReviewBaseAgent({
+        foregroundAgent: input.foregroundAgent,
+        originalPromptText: input.originalPromptText,
+      })
+      if (!resolvedBaseAgent) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      const plan = args.reviewerResolver.forBaseAgent(resolvedBaseAgent, "direct")
+      if (plan.kind === "disabled") {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      if (plan.kind === "primary-only" && plan.scope === "direct") {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      if (plan.kind !== "fan-out" || plan.scope !== "direct") {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      if (!input.messageId) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      return createPolicyResult<RuntimeEffect>([
+        {
+          type: "runReviewerFanOut",
+          sessionId: input.sessionId,
+          plan,
+          capturedPrimaryOutput: input.assistantText,
+          promptText: input.originalPromptText,
+          originalContext: input.originalPromptText,
+          idempotencyKey: `${input.sessionId}:${input.messageId}`,
+          delivery: { kind: "injectPromptAsync" },
+        },
+      ])
+    },
+    onSessionIdle(_input: RuntimeSessionIdleInput): PolicyResult<RuntimeEffect> {
+      return createPolicyResult<RuntimeEffect>()
+    },
+    onSessionDeleted(_input: RuntimeSessionDeletedInput): PolicyResult<RuntimeEffect> {
+      return createPolicyResult<RuntimeEffect>()
+    },
+    beforeCompaction(_input: RuntimeBeforeCompactionInput): void {
+      return
+    },
+    onCompaction(_input: RuntimeCompactionInput): PolicyResult<RuntimeEffect> {
+      return createPolicyResult<RuntimeEffect>()
+    },
+  }
+}
+
+function resolveDirectReviewBaseAgent(input: {
+  foregroundAgent?: string | null
+  originalPromptText: string
+}): "weft" | "warp" | null {
+  const configuredForeground = input.foregroundAgent ? getAgentConfigKey(input.foregroundAgent) : null
+  if (configuredForeground === "weft" || configuredForeground === "warp") {
+    return configuredForeground
+  }
+
+  return resolveExplicitMentionBaseAgent(input.originalPromptText)
+}
+
+function resolveExplicitMentionBaseAgent(promptText: string): "weft" | "warp" | null {
+  const hasWeftMention = /(^|[^\w])@weft\b/i.test(promptText)
+  const hasWarpMention = /(^|[^\w])@warp\b/i.test(promptText)
+
+  if (hasWeftMention && hasWarpMention) {
+    return null
+  }
+
+  if (hasWeftMention) {
+    return "weft"
+  }
+
+  if (hasWarpMention) {
+    return "warp"
+  }
+
+  return null
+}

--- a/src/application/policy/policy-engine.test.ts
+++ b/src/application/policy/policy-engine.test.ts
@@ -151,6 +151,7 @@ describe("createPolicyEngine", () => {
     })
 
     const effects = await engine.onAssistantMessage({
+      directory: "",
       sessionId: "sess-ctx",
       hooks: makeHooks({
         contextWindowThresholds: { warningPct: 0.8, criticalPct: 0.95 },

--- a/src/application/policy/post-execution-reviewer-fanout-session-policy.test.ts
+++ b/src/application/policy/post-execution-reviewer-fanout-session-policy.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import type { ReviewerPlan } from "../../agents/review-resolver"
+import { DEFAULT_CONTINUATION_CONFIG } from "../../config/continuation"
+import { createWorkState, readWorkState, writeWorkState } from "../../features/work-state"
+import { PLANS_DIR } from "../../features/work-state/constants"
+import type { CreatedHooks } from "../../hooks/create-hooks"
+import { createHookBackedSessionPolicy } from "./session-policy"
+import { createPostExecutionReviewerFanOutSessionPolicy } from "./post-execution-reviewer-fanout-session-policy"
+
+function makeHooks(overrides?: Partial<CreatedHooks>): CreatedHooks {
+  return {
+    contextWindowThresholds: null,
+    rulesInjectorEnabled: false,
+    writeGuard: null,
+    firstMessageVariant: null,
+    processMessageForKeywords: null,
+    patternMdOnlyEnabled: false,
+    startWork: null,
+    workContinuation: null,
+    workflowStart: null,
+    workflowContinuation: null,
+    workflowCommand: null,
+    verificationReminderEnabled: false,
+    analyticsEnabled: false,
+    todoDescriptionOverrideEnabled: false,
+    compactionTodoPreserverEnabled: false,
+    todoContinuationEnforcerEnabled: false,
+    compactionRecovery: null,
+    continuation: DEFAULT_CONTINUATION_CONFIG,
+    ...overrides,
+  }
+}
+
+function makePlan(baseAgent: "weft" | "warp", kind: ReviewerPlan["kind"] = "fan-out"): ReviewerPlan {
+  if (kind === "disabled") {
+    return { kind: "disabled", scope: "post-execution", baseAgent, reason: "agent-disabled" }
+  }
+
+  if (kind === "primary-only") {
+    return {
+      kind: "primary-only",
+      scope: "post-execution",
+      baseAgent,
+      primary: { agentName: baseAgent, label: baseAgent === "weft" ? "Weft" : "Warp", model: "primary" },
+      reason: "no-variants",
+    }
+  }
+
+  return {
+    kind: "fan-out",
+    scope: "post-execution",
+    baseAgent,
+    primary: { agentName: baseAgent, label: baseAgent === "weft" ? "Weft" : "Warp", model: "primary" },
+    variants: [{ baseAgent, key: `${baseAgent}-review-v1`, model: "variant-1", label: `${baseAgent} @ variant-1` }],
+    batch: { mode: "parallel", size: 2 },
+  }
+}
+
+describe("createPostExecutionReviewerFanOutSessionPolicy", () => {
+  it("emits one runReviewerFanOut effect per non-disabled base agent", () => {
+    const policy = createPostExecutionReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent(baseAgent) {
+          return baseAgent === "weft" ? makePlan("weft", "fan-out") : makePlan("warp", "disabled")
+        },
+      },
+    })
+
+    const directory = mkdtempSync(join(tmpdir(), "weave-postexec-reviewers-"))
+    const plansDir = join(directory, PLANS_DIR)
+    mkdirSync(plansDir, { recursive: true })
+    const planPath = join(plansDir, "done.md")
+    writeFileSync(planPath, "# Plan\n- [x] Done\n", "utf-8")
+    writeWorkState(directory, {
+      ...createWorkState(planPath, "sess-a", "tapestry", directory),
+      session_ids: ["sess-a"],
+    })
+
+    try {
+      const result = policy.onSessionIdle({
+        directory,
+        sessionId: "sess-a",
+        hooks: makeHooks(),
+      })
+
+      expect(result.effects).toHaveLength(1)
+      expect(result.effects[0]).toMatchObject({
+        type: "runReviewerFanOut",
+        sessionId: "sess-a",
+      })
+      const promptText = (result.effects[0] as { promptText: string }).promptText
+      const originalContext = (result.effects[0] as { originalContext: string }).originalContext
+      expect(promptText).toContain("Plan: done")
+      expect(promptText).toContain("Review scope summary")
+      expect(promptText).toContain("Planned files")
+      expect(originalContext).toContain("Plan: done")
+      expect(originalContext).toContain("Review scope summary")
+      const idempotencyKey = (result.effects[0] as { idempotencyKey?: unknown }).idempotencyKey
+      expect(typeof idempotencyKey).toBe("string")
+      expect(String(idempotencyKey)).toContain("sess-a:")
+      expect(String(idempotencyKey)).toContain(":weft")
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("is idempotent across repeated onSessionIdle via work state", () => {
+    const policy = createPostExecutionReviewerFanOutSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent(baseAgent) {
+          return makePlan(baseAgent, "primary-only")
+        },
+      },
+    })
+
+    const directory = mkdtempSync(join(tmpdir(), "weave-postexec-idempotent-"))
+    const plansDir = join(directory, PLANS_DIR)
+    mkdirSync(plansDir, { recursive: true })
+    const planPath = join(plansDir, "done.md")
+    writeFileSync(planPath, "# Plan\n- [x] Done\n", "utf-8")
+    writeWorkState(directory, {
+      ...createWorkState(planPath, "sess-b", "tapestry", directory),
+      session_ids: ["sess-b"],
+    })
+
+    try {
+      const first = policy.onSessionIdle({ directory, sessionId: "sess-b", hooks: makeHooks() })
+      const second = policy.onSessionIdle({ directory, sessionId: "sess-b", hooks: makeHooks() })
+
+      expect(first.effects).toHaveLength(2)
+      expect(second.effects).toEqual([])
+      expect(readWorkState(directory)?.reviewer_fanout_sent).toBe(true)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("coexists with verification reminder and emits fan-out before reminder", async () => {
+    const policy = createHookBackedSessionPolicy({
+      reviewerResolver: {
+        forBaseAgent(baseAgent) {
+          return makePlan(baseAgent, "primary-only")
+        },
+      },
+    })
+
+    const directory = mkdtempSync(join(tmpdir(), "weave-postexec-order-"))
+    const plansDir = join(directory, PLANS_DIR)
+    mkdirSync(plansDir, { recursive: true })
+    const planPath = join(plansDir, "done.md")
+    writeFileSync(planPath, "# Plan\n- [x] Done\n", "utf-8")
+    writeWorkState(directory, {
+      ...createWorkState(planPath, "sess-c", "tapestry", directory),
+      session_ids: ["sess-c"],
+    })
+
+    try {
+      const first = await policy.onSessionIdle({
+        directory,
+        sessionId: "sess-c",
+        hooks: makeHooks({ verificationReminderEnabled: true }),
+      })
+      const second = await policy.onSessionIdle({
+        directory,
+        sessionId: "sess-c",
+        hooks: makeHooks({ verificationReminderEnabled: true }),
+      })
+
+      expect(first.effects).toHaveLength(3)
+      expect(first.effects[0]).toMatchObject({ type: "runReviewerFanOut" })
+      expect(first.effects[1]).toMatchObject({ type: "runReviewerFanOut" })
+      expect(first.effects[2]).toMatchObject({ type: "injectPromptAsync", sessionId: "sess-c" })
+      expect(second.effects).toEqual([])
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/application/policy/post-execution-reviewer-fanout-session-policy.ts
+++ b/src/application/policy/post-execution-reviewer-fanout-session-policy.ts
@@ -1,0 +1,98 @@
+import { getPlanProgress, readWorkState, writeWorkState } from "../../features/work-state"
+import { extractPlannedFiles } from "../../features/analytics/plan-parser"
+import { createPolicyResult, type PolicyResult } from "../../domain/policy/policy-result"
+import type { ReviewerPlan } from "../../agents/review-resolver"
+import type { RuntimeEffect } from "../../runtime/opencode/effects"
+import type { RuntimeSessionIdleInput } from "./runtime-policy"
+
+export interface PostExecutionReviewerResolver {
+  forBaseAgent(baseAgent: "weft" | "warp", scope: "direct" | "post-execution"): ReviewerPlan
+}
+
+export interface PostExecutionReviewerFanOutSessionPolicy {
+  onSessionIdle(input: RuntimeSessionIdleInput): PolicyResult<RuntimeEffect>
+}
+
+function buildChangedFilesSummary(state: { plan_name: string; active_plan: string; start_sha?: string }, sessionId: string): string {
+  const plannedFiles = extractPlannedFiles(state.active_plan)
+  const plannedScope = plannedFiles.length > 0
+    ? plannedFiles.map((file) => `- ${file}`).join("\n")
+    : "- (none extracted from plan; review all relevant implementation changes in plan scope)"
+  const startShaSummary = state.start_sha
+    ? `Start SHA: ${state.start_sha}`
+    : "Start SHA: unavailable"
+
+  return [
+    "Post-execution review target context:",
+    `Session ID: ${sessionId}`,
+    `Plan: ${state.plan_name}`,
+    `Plan file: ${state.active_plan}`,
+    startShaSummary,
+    "Review scope summary:",
+    "- Primary scope: changes introduced while executing this plan.",
+    "- Source of truth for scope: Start SHA diff when available; otherwise plan Files entries.",
+    "Planned files (from plan **Files** fields):",
+    plannedScope,
+  ].join("\n")
+}
+
+export function createPostExecutionReviewerFanOutSessionPolicy(args: {
+  reviewerResolver?: PostExecutionReviewerResolver
+}): PostExecutionReviewerFanOutSessionPolicy {
+  return {
+    onSessionIdle(input) {
+      if (!input.directory || !args.reviewerResolver) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      const state = readWorkState(input.directory)
+      if (!state || state.paused) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      if (state.session_ids.length > 0 && state.session_ids.at(-1) !== input.sessionId) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      const progress = getPlanProgress(state.active_plan)
+      if (!progress.isComplete || state.reviewer_fanout_sent) {
+        return createPolicyResult<RuntimeEffect>()
+      }
+
+      const originalContext = buildChangedFilesSummary(state, input.sessionId)
+      const promptText = [
+        "You are performing a post-execution code review.",
+        "Review the completed implementation for correctness, regressions, security issues, and missing tests.",
+        "Use the following scope context and return a concise verdict with concrete issues and actionable follow-ups.",
+        "",
+        originalContext,
+      ].join("\n")
+      const effects: RuntimeEffect[] = []
+
+      for (const baseAgent of ["weft", "warp"] as const) {
+        const plan = args.reviewerResolver.forBaseAgent(baseAgent, "post-execution")
+        if (plan.kind === "disabled") {
+          continue
+        }
+
+        effects.push({
+          type: "runReviewerFanOut",
+          sessionId: input.sessionId,
+          plan,
+          capturedPrimaryOutput: undefined,
+          promptText,
+          originalContext,
+          idempotencyKey: `${input.sessionId}:${state.plan_name}:${baseAgent}`,
+          delivery: { kind: "injectPromptAsync" },
+        })
+      }
+
+      writeWorkState(input.directory, {
+        ...state,
+        reviewer_fanout_sent: true,
+      })
+
+      return createPolicyResult<RuntimeEffect>(effects)
+    },
+  }
+}

--- a/src/application/policy/runtime-policy.ts
+++ b/src/application/policy/runtime-policy.ts
@@ -1,6 +1,7 @@
 import type { CreatedHooks } from "../../hooks/create-hooks"
 import type { ParsedCommandEnvelope } from "../../runtime/opencode/command-envelope"
 import type { RuntimeEffect } from "../../runtime/opencode/effects"
+import type { TrustedInjectedPromptKind } from "../../runtime/opencode/trusted-message-state"
 
 export interface RuntimePolicyFlags {
   contextWindowThresholds: { warningPct: number; criticalPct: number } | null
@@ -67,9 +68,15 @@ export interface RuntimeBeforeCompactionInput {
 }
 
 export interface RuntimeAssistantMessageInput {
+  directory: string
   sessionId: string
   hooks: RuntimePolicyFlags
   inputTokens: number
+  foregroundAgent?: string | null
+  assistantText?: string
+  originalPromptText?: string
+  respondingToTrustedInjectedPromptKind?: TrustedInjectedPromptKind | null
+  messageId?: string
 }
 
 export interface RuntimeToolDefinitionInput {

--- a/src/application/policy/session-policy.test.ts
+++ b/src/application/policy/session-policy.test.ts
@@ -45,6 +45,7 @@ describe("createHookBackedSessionPolicy", () => {
     const policy = createHookBackedSessionPolicy()
 
     const result = await policy.onAssistantMessage({
+      directory: "",
       sessionId: "sess-ctx",
       hooks: makeHooks({
         contextWindowThresholds: { warningPct: 0.8, criticalPct: 0.95 },

--- a/src/application/policy/session-policy.ts
+++ b/src/application/policy/session-policy.ts
@@ -1,5 +1,6 @@
 import { clearTokenSession } from "../../hooks"
 import { createPolicyResult, type PolicyResult } from "../../domain/policy/policy-result"
+import type { ReviewerPlan } from "../../agents/review-resolver"
 import type { RuntimeEffect } from "../../runtime/opencode/effects"
 import { runIdleCycle } from "../orchestration/idle-cycle-service"
 import { createExecutionLeaseFsStore } from "../../infrastructure/fs/execution-lease-fs-store"
@@ -13,6 +14,7 @@ import type {
 } from "./runtime-policy"
 import { createCompactionSessionPolicy } from "./compaction-session-policy"
 import { createContextWindowSessionPolicy } from "./context-window-session-policy"
+import { createPostExecutionReviewerFanOutSessionPolicy } from "./post-execution-reviewer-fanout-session-policy"
 import { createTodoSessionPolicy } from "./todo-session-policy"
 import { createVerificationSessionPolicy } from "./verification-session-policy"
 
@@ -25,6 +27,9 @@ export interface SessionPolicy {
 }
 
 export function createHookBackedSessionPolicy(args?: {
+  reviewerResolver?: {
+    forBaseAgent(baseAgent: "weft" | "warp", scope: "direct" | "post-execution"): ReviewerPlan
+  }
   todoContinuationEnforcer?: {
     checkAndFinalize: (sessionId: string) => Promise<void>
     clearSession: (sessionId: string) => void
@@ -38,6 +43,9 @@ export function createHookBackedSessionPolicy(args?: {
   const executionLeaseRepository = createExecutionLeaseFsStore()
   const contextWindowPolicy = createContextWindowSessionPolicy()
   const todoPolicy = createTodoSessionPolicy(args?.todoContinuationEnforcer ?? null)
+  const postExecutionReviewerFanOutPolicy = createPostExecutionReviewerFanOutSessionPolicy({
+    reviewerResolver: args?.reviewerResolver,
+  })
   const verificationPolicy = createVerificationSessionPolicy()
   const compactionPolicy = createCompactionSessionPolicy(args?.compactionPreserver ?? null)
 
@@ -55,6 +63,10 @@ export function createHookBackedSessionPolicy(args?: {
           lastUserMessage: input.lastUserMessage,
           todoContinuationEnforcer: args?.todoContinuationEnforcer ?? null,
         })
+      const postExecutionReviewerResult = postExecutionReviewerFanOutPolicy.onSessionIdle(input)
+      const postExecutionReviewerEffects = postExecutionReviewerResult instanceof Promise
+        ? await postExecutionReviewerResult
+        : postExecutionReviewerResult
       const verificationResult = verificationPolicy.onSessionIdle(input)
       const verificationEffects = verificationResult instanceof Promise
         ? await verificationResult
@@ -62,6 +74,7 @@ export function createHookBackedSessionPolicy(args?: {
 
       return createPolicyResult([
         ...idleEffects,
+        ...postExecutionReviewerEffects.effects,
         ...verificationEffects.effects,
       ])
     },

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -17,6 +17,41 @@ describe("WeaveConfigSchema", () => {
     }
   })
 
+  it("parses provider-qualified review_models entries", () => {
+    const result = WeaveConfigSchema.safeParse({
+      agents: {
+        loom: {
+          review_models: ["anthropic/claude-sonnet-4", "openai/gpt-4o"],
+        },
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.agents?.loom?.review_models).toEqual([
+        "anthropic/claude-sonnet-4",
+        "openai/gpt-4o",
+      ])
+    }
+  })
+
+  it("rejects non-provider-qualified review_models entries", () => {
+    const result = WeaveConfigSchema.safeParse({
+      agents: {
+        loom: {
+          review_models: ["claude-sonnet-4"],
+        },
+      },
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        "review_models entries must be provider-qualified (e.g., 'anthropic/claude-sonnet-4')",
+      )
+    }
+  })
+
   it("parses agent override modelOptions passthrough", () => {
     const result = WeaveConfigSchema.safeParse({
       agents: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -25,6 +25,12 @@ const ModelOptionsSchema = z.record(z.string(), z.unknown())
 export const AgentOverrideConfigSchema = z.object({
   model: z.string().optional(),
   fallback_models: z.array(z.string()).optional(),
+  review_models: z.array(
+    z.string().regex(
+      /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/,
+      "review_models entries must be provider-qualified (e.g., 'anthropic/claude-sonnet-4')",
+    ),
+  ).optional(),
   variant: z.string().optional(),
   category: z.string().optional(),
   skills: z.array(z.string()).optional(),

--- a/src/features/evals/schema.test.ts
+++ b/src/features/evals/schema.test.ts
@@ -61,6 +61,97 @@ describe("eval schemas", () => {
     })
   })
 
+  it("validates builtin target variants with agentOverrides", () => {
+    const result = EvalCaseSchema.safeParse({
+      id: "loom-agent-overrides-contract",
+      title: "Loom agent overrides variant",
+      phase: "prompt",
+      target: {
+        kind: "builtin-agent-prompt",
+        agent: "loom",
+        variant: {
+          agentOverrides: {
+            weft: {
+              review_models: ["anthropic/claude-sonnet-4"],
+            },
+          },
+        },
+      },
+      executor: { kind: "prompt-render" },
+      evaluators: [{ kind: "contains-all", patterns: ["<Role>"] }],
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.target).toEqual({
+      kind: "builtin-agent-prompt",
+      agent: "loom",
+      variant: {
+        agentOverrides: {
+          weft: {
+            review_models: ["anthropic/claude-sonnet-4"],
+          },
+        },
+      },
+    })
+  })
+
+  it("validates builtin Loom target variants with agentOverrides", () => {
+    const result = EvalCaseSchema.safeParse({
+      id: "loom-agent-overrides-contract",
+      title: "Loom agentOverrides variant",
+      phase: "prompt",
+      target: {
+        kind: "builtin-agent-prompt",
+        agent: "loom",
+        variant: {
+          agentOverrides: {
+            loom: { model: "openrouter/openai/gpt-5" },
+            weft: { review_models: ["anthropic/claude-sonnet-4"] },
+          },
+        },
+      },
+      executor: { kind: "prompt-render" },
+      evaluators: [{ kind: "contains-all", patterns: ["<Role>"] }],
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.target).toEqual({
+      kind: "builtin-agent-prompt",
+      agent: "loom",
+      variant: {
+        agentOverrides: {
+          loom: { model: "openrouter/openai/gpt-5" },
+          weft: { review_models: ["anthropic/claude-sonnet-4"] },
+        },
+      },
+    })
+  })
+
+  it("rejects malformed builtin target agentOverrides", () => {
+    const result = EvalCaseSchema.safeParse({
+      id: "loom-agent-overrides-invalid",
+      title: "Invalid agentOverrides variant",
+      phase: "prompt",
+      target: {
+        kind: "builtin-agent-prompt",
+        agent: "loom",
+        variant: {
+          agentOverrides: {
+            weft: { review_models: ["claude-sonnet-4"] },
+          },
+        },
+      },
+      executor: { kind: "prompt-render" },
+      evaluators: [{ kind: "contains-all", patterns: ["<Role>"] }],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
   it("rejects malformed builtin Tapestry target categories", () => {
     const result = EvalCaseSchema.safeParse({
       id: "tapestry-categories-invalid",
@@ -73,6 +164,29 @@ describe("eval schemas", () => {
           categories: {
             frontend: {
               patterns: [123],
+            },
+          },
+        },
+      },
+      executor: { kind: "prompt-render" },
+      evaluators: [{ kind: "contains-all", patterns: ["<Role>"] }],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects malformed builtin target agentOverrides", () => {
+    const result = EvalCaseSchema.safeParse({
+      id: "loom-agent-overrides-invalid",
+      title: "Invalid Loom agent overrides variant",
+      phase: "prompt",
+      target: {
+        kind: "builtin-agent-prompt",
+        agent: "loom",
+        variant: {
+          agentOverrides: {
+            weft: {
+              review_models: ["claude-sonnet-4"],
             },
           },
         },

--- a/src/features/evals/schema.ts
+++ b/src/features/evals/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { CategoriesConfigSchema } from "../../config/schema"
+import { AgentOverridesSchema, CategoriesConfigSchema } from "../../config/schema"
 import {
   EVAL_PHASES,
   EVAL_ROUTING_KINDS,
@@ -26,6 +26,7 @@ export const EvalSuiteMetadataSchema = z.object({
 export const BuiltinAgentPromptVariantSchema = z.object({
   disabledAgents: z.array(NonEmptyString).optional(),
   categories: CategoriesConfigSchema.optional(),
+  agentOverrides: AgentOverridesSchema.optional(),
 })
 
 export const BuiltinAgentPromptTargetSchema = z.object({

--- a/src/features/evals/targets/builtin-agent-target.test.ts
+++ b/src/features/evals/targets/builtin-agent-target.test.ts
@@ -34,6 +34,41 @@ describe("resolveBuiltinAgentTarget", () => {
     expect(result.artifacts.renderedPrompt).not.toContain("MUST use Warp")
   })
 
+  it("accepts agentOverrides variants for Loom prompt composition", () => {
+    const result = resolveBuiltinAgentTarget({
+      kind: "builtin-agent-prompt",
+      agent: "loom",
+      variant: {
+        disabledAgents: ["warp"],
+        agentOverrides: {
+          loom: { model: "openrouter/openai/gpt-5" },
+          weft: { review_models: ["anthropic/claude-sonnet-4"] },
+        },
+      },
+    })
+
+    expect(result.artifacts.agentMetadata?.sourceKind).toBe("composer")
+    expect(result.artifacts.renderedPrompt).toContain("<PlanWorkflow>")
+    expect(result.artifacts.renderedPrompt).not.toContain("MUST use Warp")
+  })
+
+  it("accepts agentOverrides variants for Loom", () => {
+    const result = resolveBuiltinAgentTarget({
+      kind: "builtin-agent-prompt",
+      agent: "loom",
+      variant: {
+        disabledAgents: ["warp"],
+        agentOverrides: {
+          weft: { review_models: ["anthropic/claude-sonnet-4"] },
+        },
+      } as any,
+    })
+
+    expect(result.artifacts.agentMetadata?.sourceKind).toBe("composer")
+    expect(result.artifacts.renderedPrompt).toContain("<PlanWorkflow>")
+    expect(result.artifacts.renderedPrompt).not.toContain("MUST use Warp")
+  })
+
   it("resolves default-agent prompts", () => {
     const result = resolveBuiltinAgentTarget({ kind: "builtin-agent-prompt", agent: "thread" })
     expect(result.artifacts.agentMetadata?.sourceKind).toBe("default")
@@ -94,5 +129,43 @@ describe("resolveBuiltinAgentTarget", () => {
     expect(delegationSection).toContain("shuttle-backend")
     expect(delegationSection).not.toContain("shuttle-docs")
     expect(delegationSection).not.toContain("shuttle-{category}")
+  })
+
+  it("accepts agentOverrides variants for Tapestry", () => {
+    const result = resolveBuiltinAgentTarget({
+      kind: "builtin-agent-prompt",
+      agent: "tapestry",
+      variant: {
+        categories: {
+          frontend: { patterns: ["src/**"] },
+        },
+        agentOverrides: {
+          weft: { review_models: ["anthropic/claude-sonnet-4"] },
+        },
+      } as any,
+    })
+
+    expect(result.artifacts.agentMetadata?.sourceKind).toBe("composer")
+    expect(result.artifacts.renderedPrompt).toContain("<CategoryRouting>")
+    expect(result.artifacts.renderedPrompt).toContain("shuttle-frontend")
+  })
+
+  it("accepts combined categories and agentOverrides variants for Tapestry prompt composition", () => {
+    const result = resolveBuiltinAgentTarget({
+      kind: "builtin-agent-prompt",
+      agent: "tapestry",
+      variant: {
+        categories: {
+          frontend: { patterns: ["src/**"] },
+        },
+        agentOverrides: {
+          tapestry: { model: "openrouter/openai/gpt-5" },
+        },
+      },
+    })
+
+    expect(result.artifacts.agentMetadata?.sourceKind).toBe("composer")
+    expect(result.artifacts.renderedPrompt).toContain("<CategoryRouting>")
+    expect(result.artifacts.renderedPrompt).toContain("shuttle-frontend: patterns [src/**]")
   })
 })

--- a/src/features/evals/targets/builtin-agent-target.ts
+++ b/src/features/evals/targets/builtin-agent-target.ts
@@ -8,6 +8,7 @@ import { SPINDLE_DEFAULTS } from "../../../agents/spindle/default"
 import { WEFT_DEFAULTS } from "../../../agents/weft/default"
 import { WARP_DEFAULTS } from "../../../agents/warp/default"
 import { SHUTTLE_DEFAULTS } from "../../../agents/shuttle/default"
+import { buildReviewModelVariants } from "../../../agents/review-model-variants"
 import type { BuiltinAgentPromptTarget, ResolvedTarget } from "../types"
 
 function cloneTools(tools: Record<string, boolean> | undefined): Record<string, boolean> {
@@ -16,10 +17,16 @@ function cloneTools(tools: Record<string, boolean> | undefined): Record<string, 
 
 export function resolveBuiltinAgentTarget(target: BuiltinAgentPromptTarget): ResolvedTarget {
   const disabledAgents = new Set(target.variant?.disabledAgents ?? [])
+  const agentOverrides = target.variant?.agentOverrides
+  const reviewModelVariants = buildReviewModelVariants(agentOverrides, disabledAgents)
 
   switch (target.agent) {
     case "loom": {
-      const renderedPrompt = composeLoomPrompt({ disabledAgents })
+      const renderedPrompt = composeLoomPrompt({
+        disabledAgents,
+        agentOverrides,
+        reviewModelVariants,
+      } as Parameters<typeof composeLoomPrompt>[0])
       return {
         target,
         artifacts: {
@@ -38,7 +45,9 @@ export function resolveBuiltinAgentTarget(target: BuiltinAgentPromptTarget): Res
       const renderedPrompt = composeTapestryPrompt({
         disabledAgents,
         categories: target.variant?.categories,
-      })
+        agentOverrides,
+        reviewModelVariants,
+      } as Parameters<typeof composeTapestryPrompt>[0])
       return {
         target,
         artifacts: {

--- a/src/features/evals/types.ts
+++ b/src/features/evals/types.ts
@@ -1,5 +1,5 @@
 import type { WeaveAgentName } from "../../agents/types"
-import type { CategoriesConfig } from "../../config/schema"
+import type { AgentOverrides, CategoriesConfig } from "../../config/schema"
 
 export const EVAL_PHASES = ["prompt", "routing", "trajectory", "experimental"] as const
 export type EvalPhase = (typeof EVAL_PHASES)[number]
@@ -38,6 +38,7 @@ export type BuiltinEvalAgentName = WeaveAgentName
 export interface BuiltinAgentPromptVariant {
   disabledAgents?: string[]
   categories?: CategoriesConfig
+  agentOverrides?: AgentOverrides
 }
 
 export interface BuiltinAgentPromptTarget {

--- a/src/features/work-state/types.ts
+++ b/src/features/work-state/types.ts
@@ -56,6 +56,8 @@ export interface WorkState {
   stale_continuation_count?: number
   /** Whether the completion verification reminder was already sent */
   verification_reminder_sent?: boolean
+  /** Whether post-execution reviewer fan-out was already emitted */
+  reviewer_fanout_sent?: boolean
 }
 
 /**

--- a/src/hooks/verification-reminder.ts
+++ b/src/hooks/verification-reminder.ts
@@ -36,11 +36,11 @@ Before marking this task complete, verify the work:
 3. **Validate behavior**: Does the code actually do what was requested?
 4. **Gate decision**: Can you explain what every changed line does?
 
-If uncertain about quality, delegate to \`weft\` agent for a formal review:
-\`call_weave_agent(agent="weft", prompt="Review the changes for [task description]")\`
+If uncertain about quality, use the Task tool to delegate to \`weft\` for a formal review:
+\`Task(subagent_type="weft", prompt="Review the changes for [task description]")\`
 
-MANDATORY: If changes touch auth, crypto, certificates, tokens, signatures, or input validation, you MUST delegate to \`warp\` agent for a security audit — this is NOT optional:
-\`call_weave_agent(agent="warp", prompt="Security audit the changes for [task description]")\`
+MANDATORY: If changes touch auth, crypto, certificates, tokens, signatures, or input validation, you MUST use the Task tool to delegate to \`warp\` for a security audit — this is NOT optional:
+\`Task(subagent_type="warp", prompt="Security audit the changes for [task description]")\`
 
 Only mark complete when ALL checks pass.`,
   }

--- a/src/hooks/verification-reminder.ts
+++ b/src/hooks/verification-reminder.ts
@@ -39,7 +39,7 @@ Before marking this task complete, verify the work:
 If uncertain about quality, use the Task tool to delegate to \`weft\` for a formal review:
 \`Task(subagent_type="weft", prompt="Review the changes for [task description]")\`
 
-MANDATORY: If changes touch auth, crypto, certificates, tokens, signatures, or input validation, you MUST use the Task tool to delegate to \`warp\` for a security audit — this is NOT optional:
+MANDATORY: If changes touch auth, crypto, certificates, tokens, signatures, or input validation, you MUST delegate to \`warp\` using the Task tool for a security audit — this is NOT optional:
 \`Task(subagent_type="warp", prompt="Security audit the changes for [task description]")\`
 
 Only mark complete when ALL checks pass.`,

--- a/src/plugin/plugin-interface.test.ts
+++ b/src/plugin/plugin-interface.test.ts
@@ -65,6 +65,69 @@ function makeMockConfigHandler(): ConfigHandler & { callCount: number } {
   return handler
 }
 
+function makeMockReviewClient(args?: {
+  reviewerOutputs?: Record<string, string>
+  failingReviewModels?: string[]
+  collatedOutput?: string
+  failCollation?: boolean
+}) {
+  const reviewerOutputs = args?.reviewerOutputs ?? {}
+  const failingReviewModels = new Set(args?.failingReviewModels ?? [])
+  const collatedOutput = args?.collatedOutput ?? "Collated review output"
+  const failCollation = args?.failCollation ?? false
+  let nextSessionId = 1
+  const reviewerModelsBySessionId = new Map<string, string>()
+  const state = {
+    createCalls: [] as Array<Record<string, unknown>>,
+    promptCalls: [] as Array<Record<string, unknown>>,
+    collatePrompts: [] as string[],
+  }
+
+  const client = {
+    session: {
+      create: async (input: Record<string, unknown>) => {
+        state.createCalls.push(input)
+        return { data: { id: `review-session-${nextSessionId++}` } }
+      },
+      promptAsync: async (_input: Record<string, unknown>) => {
+      },
+      prompt: async (input: Record<string, unknown>) => {
+        state.promptCalls.push(input)
+        const sessionId =
+          ((input.path as { id?: string } | undefined)?.id)
+          ?? (input.sessionID as string | undefined)
+          ?? ""
+        const modelOverride = input.body && typeof input.body === "object"
+          ? ((input.body as { model?: { providerID?: string; modelID?: string } }).model)
+          : undefined
+        const model = modelOverride?.providerID && modelOverride.modelID
+          ? `${modelOverride.providerID}/${modelOverride.modelID}`
+          : ""
+
+        reviewerModelsBySessionId.set(sessionId, model)
+
+        if (failingReviewModels.has(model)) {
+          throw new Error(`Reviewer failed: ${model}`)
+        }
+
+        const body = input.body as { parts?: Array<{ type?: string; text?: string }> } | undefined
+        const promptText = body?.parts?.find((part) => part.type === "text")?.text ?? ""
+        if (promptText.includes("You are collating multiple AI review outputs into a single consolidated review.")) {
+          state.collatePrompts.push(promptText)
+          if (failCollation) {
+            throw new Error("Collation failed")
+          }
+          return { data: { output: collatedOutput } }
+        }
+
+        return { data: { output: reviewerOutputs[model] ?? "" } }
+      },
+    },
+  } as NonNullable<Parameters<typeof createPluginInterface>[0]["client"]>
+
+  return { client, state }
+}
+
 async function primeBuiltinCommand(
   iface: PluginInterface,
   input: { command: "start-work" | "run-workflow" | "metrics" | "token-report" | "weave-health"; sessionID: string; arguments?: string },
@@ -1316,6 +1379,349 @@ describe("delegation logging via tool hooks", () => {
     ])
 
     spy.mockRestore()
+  })
+})
+
+describe("call_weave_agent review orchestration via tool.execute.after", () => {
+  it("leaves output unchanged when target agent has no review_models configured", async () => {
+    const { client, state } = makeMockReviewClient()
+    const iface = createPluginInterface({
+      pluginConfig: {
+        agents: {
+          warp: { model: "anthropic/claude-3-5-sonnet" },
+        },
+      },
+      hooks: makeHooks(),
+      tools: emptyTools,
+      configHandler: makeMockConfigHandler(),
+      agents: {},
+      client,
+    })
+
+    const output = {
+      title: "Warp Review",
+      output: "Primary warp review",
+    }
+
+    await iface["tool.execute.after"](
+      {
+        tool: "call_weave_agent",
+        sessionID: "sess-no-review-models",
+        callID: "call-no-review-models",
+        args: { agent: "warp", prompt: "Review this change" },
+      } as Parameters<typeof iface["tool.execute.after"]>[0],
+      output,
+    )
+
+    expect(output).toEqual({
+      title: "Warp Review",
+      output: "Primary warp review",
+    })
+    expect(state.createCalls).toHaveLength(0)
+    expect(state.promptCalls).toHaveLength(0)
+  })
+
+  it("replaces output with collated review and updates title when review_models are configured", async () => {
+    const { client, state } = makeMockReviewClient({
+      reviewerOutputs: {
+        "openai/gpt-4o": "Additional reviewer found one more issue.",
+      },
+      collatedOutput: "Collated multi-model review",
+    })
+
+    const iface = createPluginInterface({
+      pluginConfig: {
+        agents: {
+          weft: {
+            model: "anthropic/claude-3-5-sonnet",
+            review_models: ["openai/gpt-4o"],
+          },
+        },
+      },
+      hooks: makeHooks(),
+      tools: emptyTools,
+      configHandler: makeMockConfigHandler(),
+      agents: {},
+      client,
+    })
+
+    const output = {
+      title: "Weft",
+      output: "Primary weft review",
+    }
+
+    await iface["tool.execute.after"](
+      {
+        tool: "call_weave_agent",
+        sessionID: "sess-review-models",
+        callID: "call-review-models",
+        args: { agent: "weft", prompt: "Review this patch" },
+      } as Parameters<typeof iface["tool.execute.after"]>[0],
+      output,
+    )
+
+    expect(output.output).toBe("Collated multi-model review")
+    expect(output.title).toBe("weft Review (2 models)")
+    expect(state.createCalls).toHaveLength(2)
+    expect(state.promptCalls).toHaveLength(2)
+    expect(state.collatePrompts[0]).toContain("## Primary reviewer: anthropic/claude-3-5-sonnet")
+    expect(state.collatePrompts[0]).toContain("Primary weft review")
+    expect(state.collatePrompts[0]).toContain("Additional reviewer found one more issue.")
+    const collateCall = state.promptCalls[1] as { body?: { agent?: string } }
+    expect(collateCall.body?.agent).toBe("weft")
+  })
+
+  it("skips review orchestration when tracked client is unavailable", async () => {
+    const iface = createPluginInterface({
+      pluginConfig: {
+        agents: {
+          weft: {
+            model: "anthropic/claude-3-5-sonnet",
+            review_models: ["openai/gpt-4o"],
+          },
+        },
+      },
+      hooks: makeHooks(),
+      tools: emptyTools,
+      configHandler: makeMockConfigHandler(),
+      agents: {},
+    })
+
+    const output = {
+      title: "Weft",
+      output: "Primary weft review",
+    }
+
+    await iface["tool.execute.after"](
+      {
+        tool: "call_weave_agent",
+        sessionID: "sess-no-client",
+        callID: "call-no-client",
+        args: { agent: "weft", prompt: "Review this patch" },
+      } as Parameters<typeof iface["tool.execute.after"]>[0],
+      output,
+    )
+
+    expect(output).toEqual({
+      title: "Weft",
+      output: "Primary weft review",
+    })
+  })
+
+  it("uses default fallback model for collation when no explicit agent model is configured", async () => {
+    const { client, state } = makeMockReviewClient({
+      reviewerOutputs: {
+        "openai/gpt-4o": "Additional reviewer found one more issue.",
+      },
+      collatedOutput: "Collated multi-model review",
+    })
+
+    const debugSpy = spyOn(sharedLog, "debug").mockImplementation(() => {})
+
+    try {
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: {
+            weft: {
+              review_models: ["openai/gpt-4o"],
+            },
+          },
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+      })
+
+      const output = {
+        title: "Weft",
+        output: "Primary weft review",
+      }
+
+      await iface["tool.execute.after"](
+        {
+          tool: "call_weave_agent",
+          sessionID: "sess-review-default-model",
+          callID: "call-review-default-model",
+          args: { agent: "weft", prompt: "Review this patch" },
+        } as Parameters<typeof iface["tool.execute.after"]>[0],
+        output,
+      )
+
+      expect(output.output).toBe("Collated multi-model review")
+      expect(state.collatePrompts[0]).toContain("## Primary reviewer: github-copilot/claude-sonnet-4.6")
+      expect(debugSpy).toHaveBeenCalledWith(
+        "[review-orchestration] No explicit model override — using default for collation",
+        { agent: "weft", model: "github-copilot/claude-sonnet-4.6" },
+      )
+    } finally {
+      debugSpy.mockRestore()
+    }
+  })
+
+  it("prepends a warning when one additional reviewer fails", async () => {
+    const { client, state } = makeMockReviewClient({
+      reviewerOutputs: {
+        "openai/gpt-4o": "Successful reviewer findings",
+      },
+      failingReviewModels: ["anthropic/claude-3-5-sonnet"],
+      collatedOutput: "Collated review with surviving reviewers",
+    })
+
+    const iface = createPluginInterface({
+      pluginConfig: {
+        agents: {
+          weft: {
+            model: "anthropic/claude-3-7-sonnet",
+            review_models: ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"],
+          },
+        },
+      },
+      hooks: makeHooks(),
+      tools: emptyTools,
+      configHandler: makeMockConfigHandler(),
+      agents: {},
+      client,
+    })
+
+    const output = {
+      title: "Weft",
+      output: "Primary weft review",
+    }
+
+    await iface["tool.execute.after"](
+      {
+        tool: "call_weave_agent",
+        sessionID: "sess-review-failure",
+        callID: "call-review-failure",
+        args: { agent: "weft", prompt: "Review this patch with backups" },
+      } as Parameters<typeof iface["tool.execute.after"]>[0],
+      output,
+    )
+
+    expect(output.output).toStartWith("⚠️ 1 of 2 additional review models did not respond. Results based on 2 models (including primary).")
+    expect(output.output).toContain("Collated review with surviving reviewers")
+    expect(output.title).toBe("weft Review (2 models)")
+    expect(state.createCalls).toHaveLength(3)
+    expect(state.promptCalls).toHaveLength(3)
+  })
+
+  it("preserves primary output with warning when collation fails", async () => {
+    const { client, state } = makeMockReviewClient({
+      reviewerOutputs: {
+        "openai/gpt-4o": "Additional reviewer found one more issue.",
+      },
+      failCollation: true,
+    })
+
+    const debugSpy = spyOn(sharedLog, "debug").mockImplementation(() => {})
+
+    try {
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: {
+            weft: {
+              model: "anthropic/claude-3-5-sonnet",
+              review_models: ["openai/gpt-4o"],
+            },
+          },
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+      })
+
+      const output = {
+        title: "Weft",
+        output: "Primary weft review",
+      }
+
+      await iface["tool.execute.after"](
+        {
+          tool: "call_weave_agent",
+          sessionID: "sess-review-collation-failure",
+          callID: "call-review-collation-failure",
+          args: { agent: "weft", prompt: "Review this patch" },
+        } as Parameters<typeof iface["tool.execute.after"]>[0],
+        output,
+      )
+
+      expect(output.output).toBe("⚠️ Review collation failed. Showing primary model review only.\n\nPrimary weft review")
+      expect(output.title).toBe("weft Review (1 model)")
+      expect(state.createCalls).toHaveLength(2)
+      expect(state.promptCalls).toHaveLength(2)
+      expect(debugSpy).toHaveBeenCalledWith(
+        "[review-orchestration] Collation failed; preserving primary output",
+        expect.objectContaining({
+          agent: "weft",
+          primaryModel: "anthropic/claude-3-5-sonnet",
+          error: "Collation failed",
+        }),
+      )
+    } finally {
+      debugSpy.mockRestore()
+    }
+  })
+
+  it("preserves primary output with warning when primary model is unqualified", async () => {
+    const { client, state } = makeMockReviewClient({
+      reviewerOutputs: {
+        "openai/gpt-4o": "Additional reviewer found one more issue.",
+      },
+    })
+
+    const debugSpy = spyOn(sharedLog, "debug").mockImplementation(() => {})
+
+    try {
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: {
+            weft: {
+              model: "claude-opus-4",
+              review_models: ["openai/gpt-4o"],
+            },
+          },
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+      })
+
+      const output = {
+        title: "Weft",
+        output: "Primary weft review",
+      }
+
+      await iface["tool.execute.after"](
+        {
+          tool: "call_weave_agent",
+          sessionID: "sess-review-unqualified-model",
+          callID: "call-review-unqualified-model",
+          args: { agent: "weft", prompt: "Review this patch" },
+        } as Parameters<typeof iface["tool.execute.after"]>[0],
+        output,
+      )
+
+      expect(output.output).toBe("⚠️ Review collation failed. Showing primary model review only.\n\nPrimary weft review")
+      expect(output.title).toBe("weft Review (1 model)")
+      expect(state.createCalls).toHaveLength(2)
+      expect(state.promptCalls).toHaveLength(1)
+      expect(debugSpy).toHaveBeenCalledWith(
+        "[review-orchestration] Collation failed; preserving primary output",
+        expect.objectContaining({
+          agent: "weft",
+          primaryModel: "claude-opus-4",
+          error: "Model must be provider-qualified: claude-opus-4",
+        }),
+      )
+    } finally {
+      debugSpy.mockRestore()
+    }
   })
 })
 

--- a/src/plugin/plugin-interface.test.ts
+++ b/src/plugin/plugin-interface.test.ts
@@ -1382,13 +1382,16 @@ describe("delegation logging via tool hooks", () => {
   })
 })
 
-describe("call_weave_agent review orchestration via tool.execute.after", () => {
-  it("leaves output unchanged when target agent has no review_models configured", async () => {
+describe("visible review variants via tool.execute.after", () => {
+  it("leaves call_weave_agent output unchanged even when review_models are configured", async () => {
     const { client, state } = makeMockReviewClient()
     const iface = createPluginInterface({
       pluginConfig: {
         agents: {
-          warp: { model: "anthropic/claude-3-5-sonnet" },
+          warp: {
+            model: "anthropic/claude-3-5-sonnet",
+            review_models: ["openai/gpt-4o"],
+          },
         },
       },
       hooks: makeHooks(),
@@ -1406,8 +1409,8 @@ describe("call_weave_agent review orchestration via tool.execute.after", () => {
     await iface["tool.execute.after"](
       {
         tool: "call_weave_agent",
-        sessionID: "sess-no-review-models",
-        callID: "call-no-review-models",
+        sessionID: "sess-visible-only-call-weave-agent",
+        callID: "call-visible-only-call-weave-agent",
         args: { agent: "warp", prompt: "Review this change" },
       } as Parameters<typeof iface["tool.execute.after"]>[0],
       output,
@@ -1421,20 +1424,15 @@ describe("call_weave_agent review orchestration via tool.execute.after", () => {
     expect(state.promptCalls).toHaveLength(0)
   })
 
-  it("replaces output with collated review and updates title when review_models are configured", async () => {
-    const { client, state } = makeMockReviewClient({
-      reviewerOutputs: {
-        "openai/gpt-4o": "Additional reviewer found one more issue.",
-      },
-      collatedOutput: "Collated multi-model review",
-    })
+  it("does not orchestrate review_models when Weft completes via task tool", async () => {
+    const { client, state } = makeMockReviewClient()
 
     const iface = createPluginInterface({
       pluginConfig: {
         agents: {
           weft: {
-            model: "anthropic/claude-3-5-sonnet",
-            review_models: ["openai/gpt-4o"],
+            model: "openai/gpt-5.5",
+            review_models: ["opencode-go/kimi-k2.6"],
           },
         },
       },
@@ -1446,135 +1444,35 @@ describe("call_weave_agent review orchestration via tool.execute.after", () => {
     })
 
     const output = {
-      title: "Weft",
-      output: "Primary weft review",
+      title: "weft",
+      output: "Primary task weft review",
     }
 
     await iface["tool.execute.after"](
       {
-        tool: "call_weave_agent",
-        sessionID: "sess-review-models",
-        callID: "call-review-models",
-        args: { agent: "weft", prompt: "Review this patch" },
+        tool: "task",
+        sessionID: "sess-task-review-models",
+        callID: "call-task-review-models",
+        args: { subagent_type: "weft", prompt: "Review this patch" },
       } as Parameters<typeof iface["tool.execute.after"]>[0],
       output,
     )
 
-    expect(output.output).toBe("Collated multi-model review")
-    expect(output.title).toBe("weft Review (2 models)")
-    expect(state.createCalls).toHaveLength(2)
-    expect(state.promptCalls).toHaveLength(2)
-    expect(state.collatePrompts[0]).toContain("## Primary reviewer: anthropic/claude-3-5-sonnet")
-    expect(state.collatePrompts[0]).toContain("Primary weft review")
-    expect(state.collatePrompts[0]).toContain("Additional reviewer found one more issue.")
-    const collateCall = state.promptCalls[1] as { body?: { agent?: string } }
-    expect(collateCall.body?.agent).toBe("weft")
+    expect(output.output).toBe("Primary task weft review")
+    expect(output.title).toBe("weft")
+    expect(state.createCalls).toHaveLength(0)
+    expect(state.promptCalls).toHaveLength(0)
   })
 
-  it("skips review orchestration when tracked client is unavailable", async () => {
-    const iface = createPluginInterface({
-      pluginConfig: {
-        agents: {
-          weft: {
-            model: "anthropic/claude-3-5-sonnet",
-            review_models: ["openai/gpt-4o"],
-          },
-        },
-      },
-      hooks: makeHooks(),
-      tools: emptyTools,
-      configHandler: makeMockConfigHandler(),
-      agents: {},
-    })
-
-    const output = {
-      title: "Weft",
-      output: "Primary weft review",
-    }
-
-    await iface["tool.execute.after"](
-      {
-        tool: "call_weave_agent",
-        sessionID: "sess-no-client",
-        callID: "call-no-client",
-        args: { agent: "weft", prompt: "Review this patch" },
-      } as Parameters<typeof iface["tool.execute.after"]>[0],
-      output,
-    )
-
-    expect(output).toEqual({
-      title: "Weft",
-      output: "Primary weft review",
-    })
-  })
-
-  it("uses default fallback model for collation when no explicit agent model is configured", async () => {
-    const { client, state } = makeMockReviewClient({
-      reviewerOutputs: {
-        "openai/gpt-4o": "Additional reviewer found one more issue.",
-      },
-      collatedOutput: "Collated multi-model review",
-    })
-
-    const debugSpy = spyOn(sharedLog, "debug").mockImplementation(() => {})
-
-    try {
-      const iface = createPluginInterface({
-        pluginConfig: {
-          agents: {
-            weft: {
-              review_models: ["openai/gpt-4o"],
-            },
-          },
-        },
-        hooks: makeHooks(),
-        tools: emptyTools,
-        configHandler: makeMockConfigHandler(),
-        agents: {},
-        client,
-      })
-
-      const output = {
-        title: "Weft",
-        output: "Primary weft review",
-      }
-
-      await iface["tool.execute.after"](
-        {
-          tool: "call_weave_agent",
-          sessionID: "sess-review-default-model",
-          callID: "call-review-default-model",
-          args: { agent: "weft", prompt: "Review this patch" },
-        } as Parameters<typeof iface["tool.execute.after"]>[0],
-        output,
-      )
-
-      expect(output.output).toBe("Collated multi-model review")
-      expect(state.collatePrompts[0]).toContain("## Primary reviewer: github-copilot/claude-sonnet-4.6")
-      expect(debugSpy).toHaveBeenCalledWith(
-        "[review-orchestration] No explicit model override — using default for collation",
-        { agent: "weft", model: "github-copilot/claude-sonnet-4.6" },
-      )
-    } finally {
-      debugSpy.mockRestore()
-    }
-  })
-
-  it("prepends a warning when one additional reviewer fails", async () => {
-    const { client, state } = makeMockReviewClient({
-      reviewerOutputs: {
-        "openai/gpt-4o": "Successful reviewer findings",
-      },
-      failingReviewModels: ["anthropic/claude-3-5-sonnet"],
-      collatedOutput: "Collated review with surviving reviewers",
-    })
+  it("keeps task review output unchanged when after hook omits args", async () => {
+    const { client, state } = makeMockReviewClient()
 
     const iface = createPluginInterface({
       pluginConfig: {
         agents: {
           weft: {
-            model: "anthropic/claude-3-7-sonnet",
-            review_models: ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"],
+            model: "openai/gpt-5.5",
+            review_models: ["opencode-go/glm-5.1"],
           },
         },
       },
@@ -1585,143 +1483,31 @@ describe("call_weave_agent review orchestration via tool.execute.after", () => {
       client,
     })
 
+    const toolInput = {
+      tool: "task",
+      sessionID: "sess-task-review-before-args",
+      callID: "call-task-review-before-args",
+    } as Parameters<typeof iface["tool.execute.before"]>[0]
+
+    await iface["tool.execute.before"](
+      toolInput,
+      { args: { subagent_type: "weft", prompt: "Review this captured patch" } },
+    )
+
     const output = {
-      title: "Weft",
-      output: "Primary weft review",
+      title: "weft",
+      output: "Primary captured task weft review",
     }
 
     await iface["tool.execute.after"](
-      {
-        tool: "call_weave_agent",
-        sessionID: "sess-review-failure",
-        callID: "call-review-failure",
-        args: { agent: "weft", prompt: "Review this patch with backups" },
-      } as Parameters<typeof iface["tool.execute.after"]>[0],
+      toolInput as Parameters<typeof iface["tool.execute.after"]>[0],
       output,
     )
 
-    expect(output.output).toStartWith("⚠️ 1 of 2 additional review models did not respond. Results based on 2 models (including primary).")
-    expect(output.output).toContain("Collated review with surviving reviewers")
-    expect(output.title).toBe("weft Review (2 models)")
-    expect(state.createCalls).toHaveLength(3)
-    expect(state.promptCalls).toHaveLength(3)
-  })
-
-  it("preserves primary output with warning when collation fails", async () => {
-    const { client, state } = makeMockReviewClient({
-      reviewerOutputs: {
-        "openai/gpt-4o": "Additional reviewer found one more issue.",
-      },
-      failCollation: true,
-    })
-
-    const debugSpy = spyOn(sharedLog, "debug").mockImplementation(() => {})
-
-    try {
-      const iface = createPluginInterface({
-        pluginConfig: {
-          agents: {
-            weft: {
-              model: "anthropic/claude-3-5-sonnet",
-              review_models: ["openai/gpt-4o"],
-            },
-          },
-        },
-        hooks: makeHooks(),
-        tools: emptyTools,
-        configHandler: makeMockConfigHandler(),
-        agents: {},
-        client,
-      })
-
-      const output = {
-        title: "Weft",
-        output: "Primary weft review",
-      }
-
-      await iface["tool.execute.after"](
-        {
-          tool: "call_weave_agent",
-          sessionID: "sess-review-collation-failure",
-          callID: "call-review-collation-failure",
-          args: { agent: "weft", prompt: "Review this patch" },
-        } as Parameters<typeof iface["tool.execute.after"]>[0],
-        output,
-      )
-
-      expect(output.output).toBe("⚠️ Review collation failed. Showing primary model review only.\n\nPrimary weft review")
-      expect(output.title).toBe("weft Review (1 model)")
-      expect(state.createCalls).toHaveLength(2)
-      expect(state.promptCalls).toHaveLength(2)
-      expect(debugSpy).toHaveBeenCalledWith(
-        "[review-orchestration] Collation failed; preserving primary output",
-        expect.objectContaining({
-          agent: "weft",
-          primaryModel: "anthropic/claude-3-5-sonnet",
-          error: "Collation failed",
-        }),
-      )
-    } finally {
-      debugSpy.mockRestore()
-    }
-  })
-
-  it("preserves primary output with warning when primary model is unqualified", async () => {
-    const { client, state } = makeMockReviewClient({
-      reviewerOutputs: {
-        "openai/gpt-4o": "Additional reviewer found one more issue.",
-      },
-    })
-
-    const debugSpy = spyOn(sharedLog, "debug").mockImplementation(() => {})
-
-    try {
-      const iface = createPluginInterface({
-        pluginConfig: {
-          agents: {
-            weft: {
-              model: "claude-opus-4",
-              review_models: ["openai/gpt-4o"],
-            },
-          },
-        },
-        hooks: makeHooks(),
-        tools: emptyTools,
-        configHandler: makeMockConfigHandler(),
-        agents: {},
-        client,
-      })
-
-      const output = {
-        title: "Weft",
-        output: "Primary weft review",
-      }
-
-      await iface["tool.execute.after"](
-        {
-          tool: "call_weave_agent",
-          sessionID: "sess-review-unqualified-model",
-          callID: "call-review-unqualified-model",
-          args: { agent: "weft", prompt: "Review this patch" },
-        } as Parameters<typeof iface["tool.execute.after"]>[0],
-        output,
-      )
-
-      expect(output.output).toBe("⚠️ Review collation failed. Showing primary model review only.\n\nPrimary weft review")
-      expect(output.title).toBe("weft Review (1 model)")
-      expect(state.createCalls).toHaveLength(2)
-      expect(state.promptCalls).toHaveLength(1)
-      expect(debugSpy).toHaveBeenCalledWith(
-        "[review-orchestration] Collation failed; preserving primary output",
-        expect.objectContaining({
-          agent: "weft",
-          primaryModel: "claude-opus-4",
-          error: "Model must be provider-qualified: claude-opus-4",
-        }),
-      )
-    } finally {
-      debugSpy.mockRestore()
-    }
+    expect(output.output).toBe("Primary captured task weft review")
+    expect(output.title).toBe("weft")
+    expect(state.createCalls).toHaveLength(0)
+    expect(state.promptCalls).toHaveLength(0)
   })
 })
 

--- a/src/plugin/plugin-interface.test.ts
+++ b/src/plugin/plugin-interface.test.ts
@@ -80,6 +80,7 @@ function makeMockReviewClient(args?: {
   const state = {
     createCalls: [] as Array<Record<string, unknown>>,
     promptCalls: [] as Array<Record<string, unknown>>,
+    promptAsyncCalls: [] as Array<Record<string, unknown>>,
     collatePrompts: [] as string[],
   }
 
@@ -90,6 +91,8 @@ function makeMockReviewClient(args?: {
         return { data: { id: `review-session-${nextSessionId++}` } }
       },
       promptAsync: async (_input: Record<string, unknown>) => {
+        state.promptAsyncCalls.push(_input)
+        state.promptCalls.push(_input)
       },
       prompt: async (input: Record<string, unknown>) => {
         state.promptCalls.push(input)
@@ -1382,7 +1385,7 @@ describe("delegation logging via tool hooks", () => {
   })
 })
 
-describe("visible review variants via tool.execute.after", () => {
+describe("tool.execute.after leaves output untouched — fan-out lives elsewhere", () => {
   it("leaves call_weave_agent output unchanged even when review_models are configured", async () => {
     const { client, state } = makeMockReviewClient()
     const iface = createPluginInterface({
@@ -1508,6 +1511,386 @@ describe("visible review variants via tool.execute.after", () => {
     expect(output.title).toBe("weft")
     expect(state.createCalls).toHaveLength(0)
     expect(state.promptCalls).toHaveLength(0)
+  })
+})
+
+describe("direct-intent reviewer fan-out via message.updated / onAssistantMessage", () => {
+  it("fans out Weft review variants from explicit @weft mention in Loom session prompt", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-fanout-mention-weft-"))
+    try {
+      const { client, state } = makeMockReviewClient({
+        reviewerOutputs: { "opencode-go/kimi-k2.6": "Weft variant verdict" },
+        collatedOutput: "Collated Weft verdict from mention path",
+      })
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: {
+            weft: {
+              model: "openai/gpt-5.5",
+              review_models: ["opencode-go/kimi-k2.6"],
+            },
+          },
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s-mention", agent: "loom" } as never, {} as never)
+      await iface["chat.message"](
+        { sessionID: "s-mention" },
+        { message: {} as never, parts: [{ type: "text", text: "Puedes probar con @weft el ultimo commit?" }] as never },
+      )
+      await iface.event({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            part: { type: "text", sessionID: "s-mention", messageID: "m-mention-1", text: "Primary Loom-routed review text" },
+          },
+        } as never,
+      })
+      await iface.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg-mention-weft-1", role: "assistant", sessionID: "s-mention", tokens: { input: 42 } },
+          },
+        } as never,
+      })
+
+      expect(state.createCalls.length).toBe(2)
+      expect(state.promptCalls.length).toBe(3)
+      expect(state.promptAsyncCalls.length).toBe(1)
+      const variantPromptCall = state.promptCalls.find((call) => {
+        const model = (call.body as { model?: { providerID?: string; modelID?: string } } | undefined)?.model
+        return model?.providerID === "opencode-go" && model?.modelID === "kimi-k2.6"
+      })
+      const variantPromptText = ((variantPromptCall?.body as { parts?: Array<{ type?: string; text?: string }> } | undefined)
+        ?.parts?.find((part) => part.type === "text")?.text) ?? ""
+      expect(variantPromptText).toContain("Puedes probar con @weft el ultimo commit?")
+      expect(variantPromptText).not.toContain("Primary Loom-routed review text")
+
+      const postedText = ((state.promptAsyncCalls[0].body as { parts: Array<{ text?: string }> }).parts[0]?.text ?? "")
+      expect(postedText).toContain("Collated Weft verdict from mention path")
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("fans out Weft direct-intent review, uses original user request for variant prompt, and is idempotent by message id", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-fanout-weft-"))
+    try {
+      const { client, state } = makeMockReviewClient({
+        reviewerOutputs: { "opencode-go/kimi-k2.6": "Weft variant verdict" },
+        collatedOutput: "Collated Weft verdict",
+      })
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: {
+            weft: {
+              model: "openai/gpt-5.5",
+              review_models: ["opencode-go/kimi-k2.6"],
+            },
+          },
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s1", agent: "weft" } as never, {} as never)
+      await iface["chat.message"](
+        { sessionID: "s1" },
+        { message: {} as never, parts: [{ type: "text", text: "Review my auth refactor" }] as never },
+      )
+      await iface.event({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            part: { type: "text", sessionID: "s1", messageID: "m1", text: "Primary Weft verdict text" },
+          },
+        } as never,
+      })
+
+      await iface.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg-weft-1", role: "assistant", sessionID: "s1", tokens: { input: 42 } },
+          },
+        } as never,
+      })
+
+      expect(state.createCalls.length).toBe(2)
+      expect(state.promptCalls.length).toBe(3)
+      expect(state.promptAsyncCalls.length).toBe(1)
+      expect((state.promptAsyncCalls[0].path as { id: string }).id).toBe("s1")
+      const postedText = ((state.promptAsyncCalls[0].body as { parts: Array<{ text?: string }> }).parts[0]?.text ?? "")
+      expect(postedText).toContain("Collated Weft verdict")
+
+      const variantPromptCall = state.promptCalls.find((call) => {
+        const model = (call.body as { model?: { providerID?: string; modelID?: string } } | undefined)?.model
+        return model?.providerID === "opencode-go" && model?.modelID === "kimi-k2.6"
+      })
+      const variantPromptText = ((variantPromptCall?.body as { parts?: Array<{ type?: string; text?: string }> } | undefined)
+        ?.parts?.find((part) => part.type === "text")?.text) ?? ""
+      expect(variantPromptText).toContain("Review my auth refactor")
+      expect(variantPromptText).not.toContain("Primary Weft verdict text")
+
+      const collatePrompt = state.collatePrompts[0] ?? ""
+      expect(collatePrompt).toContain("Primary Weft verdict text")
+
+      await iface.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg-weft-1", role: "assistant", sessionID: "s1", tokens: { input: 42 } },
+          },
+        } as never,
+      })
+      expect(state.createCalls.length).toBe(2)
+
+      await iface.event({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            part: { type: "text", sessionID: "s1", messageID: "m2", text: "Injected <!-- weave:reviewer-fanout --> text" },
+          },
+        } as never,
+      })
+      await iface["chat.message"](
+        { sessionID: "s1" },
+        {
+          message: {} as never,
+          parts: [
+            {
+              type: "text",
+              text: postedText,
+            },
+          ] as never,
+        },
+      )
+      await iface.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg-weft-2", role: "assistant", sessionID: "s1", tokens: { input: 42 } },
+          },
+        } as never,
+      })
+      expect(state.createCalls.length).toBe(2)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("fans out Warp direct-intent review through message.updated", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-fanout-warp-"))
+    try {
+      const { client, state } = makeMockReviewClient({
+        reviewerOutputs: { "openai/gpt-4o": "Warp variant verdict" },
+        collatedOutput: "Collated Warp verdict",
+      })
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: {
+            warp: {
+              model: "anthropic/claude-3-5-sonnet",
+              review_models: ["openai/gpt-4o"],
+            },
+          },
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s1", agent: "warp" } as never, {} as never)
+      await iface["chat.message"](
+        { sessionID: "s1" },
+        { message: {} as never, parts: [{ type: "text", text: "Audit my auth refactor" }] as never },
+      )
+      await iface.event({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            part: { type: "text", sessionID: "s1", messageID: "m1", text: "Primary Warp verdict text" },
+          },
+        } as never,
+      })
+      await iface.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg-warp-1", role: "assistant", sessionID: "s1", tokens: { input: 25 } },
+          },
+        } as never,
+      })
+
+      expect(state.createCalls.length).toBe(2)
+      expect(state.promptCalls.length).toBe(3)
+      expect(state.promptAsyncCalls.length).toBe(1)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("emits no direct fan-out when Weft has no review variants", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-fanout-none-"))
+    try {
+      const { client, state } = makeMockReviewClient()
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: { weft: { model: "openai/gpt-5.5", review_models: [] } },
+          disabled_agents: ["warp"],
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s1", agent: "weft" } as never, {} as never)
+      await iface["chat.message"]({ sessionID: "s1" }, { message: {} as never, parts: [{ type: "text", text: "Review this" }] as never })
+      await iface.event({ event: { type: "message.part.updated", properties: { part: { type: "text", sessionID: "s1", text: "Primary" } } } as never })
+      await iface.event({ event: { type: "message.updated", properties: { info: { id: "msg-1", role: "assistant", sessionID: "s1", tokens: { input: 1 } } } } as never })
+
+      expect(state.createCalls.length).toBe(0)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("runs exactly one post-execution primary-only Weft reviewer, then verification reminder", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-postexec-primary-only-"))
+    const plansDir = join(tempDir, WEAVE_DIR, "plans")
+    mkdirSync(plansDir, { recursive: true })
+    const planPath = join(plansDir, "done.md")
+    writeFileSync(planPath, "# Plan\n- [x] Done\n", "utf-8")
+    writeWorkState(tempDir, {
+      ...createWorkState(planPath, "s1", "tapestry", tempDir),
+      session_ids: ["s1"],
+    })
+
+    try {
+      const { client, state } = makeMockReviewClient({ reviewerOutputs: { "openai/gpt-5.5": "Primary-only runtime reviewer output" } })
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: { weft: { model: "openai/gpt-5.5", review_models: [] } },
+          disabled_agents: ["warp"],
+        },
+        hooks: makeHooks({ verificationReminderEnabled: true }),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface.event({ event: { type: "session.idle", properties: { sessionID: "s1" } } as never })
+
+      expect(state.createCalls.length).toBe(1)
+      expect(state.promptAsyncCalls.length).toBe(2)
+      const asyncTexts = state.promptAsyncCalls.map((call) => ((call.body as { parts?: Array<{ text?: string }> }).parts?.[0]?.text ?? ""))
+      expect(asyncTexts.some((text) => text.includes("<!-- weave:reviewer-fanout -->"))).toBe(true)
+      expect(asyncTexts.some((text) => text.includes("## Verification Required"))).toBe(true)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("degrades safely when originalPromptText is missing", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-missing-original-"))
+    try {
+      const { client, state } = makeMockReviewClient()
+      const iface = createPluginInterface({
+        pluginConfig: { agents: { weft: { model: "openai/gpt-5.5", review_models: ["opencode-go/kimi-k2.6"] } } },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s1", agent: "weft" } as never, {} as never)
+      await iface.event({ event: { type: "message.part.updated", properties: { part: { type: "text", sessionID: "s1", text: "Primary" } } } as never })
+      await iface.event({ event: { type: "message.updated", properties: { info: { id: "msg-x", role: "assistant", sessionID: "s1", tokens: { input: 1 } } } } as never })
+
+      expect(state.createCalls.length).toBe(0)
+      expect(state.promptCalls.length).toBe(0)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not run Weft fan-out when foreground agent is Warp and warp review_models are not configured", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-boundary-"))
+    try {
+      const { client, state } = makeMockReviewClient()
+      const iface = createPluginInterface({
+        pluginConfig: { agents: { weft: { model: "openai/gpt-5.5", review_models: ["opencode-go/kimi-k2.6"] } } },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s1", agent: "warp" } as never, {} as never)
+      await iface["chat.message"]({ sessionID: "s1" }, { message: {} as never, parts: [{ type: "text", text: "Security review please" }] as never })
+      await iface.event({ event: { type: "message.part.updated", properties: { part: { type: "text", sessionID: "s1", text: "Warp primary" } } } as never })
+      await iface.event({ event: { type: "message.updated", properties: { info: { id: "msg-b", role: "assistant", sessionID: "s1", tokens: { input: 1 } } } } as never })
+
+      const weftPrefixedCreates = state.createCalls.filter((call) => String((call.title as string | undefined) ?? "").toLowerCase().includes("weft"))
+      const warpVariantCreates = state.createCalls.filter((call) => String((call.title as string | undefined) ?? "").toLowerCase().includes("warp @"))
+      expect(weftPrefixedCreates.length).toBe(0)
+      expect(warpVariantCreates.length).toBe(0)
+      expect(state.createCalls.length).toBe(0)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not emit fan-out when Weft is disabled even with review_models configured", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "weave-direct-disabled-"))
+    try {
+      const { client, state } = makeMockReviewClient()
+      const iface = createPluginInterface({
+        pluginConfig: {
+          agents: { weft: { model: "openai/gpt-5.5", review_models: ["opencode-go/kimi-k2.6"] } },
+          disabled_agents: ["weft"],
+        },
+        hooks: makeHooks(),
+        tools: emptyTools,
+        configHandler: makeMockConfigHandler(),
+        agents: {},
+        client,
+        directory: tempDir,
+      })
+
+      await iface["chat.params"]({ sessionID: "s1", agent: "weft" } as never, {} as never)
+      await iface["chat.message"]({ sessionID: "s1" }, { message: {} as never, parts: [{ type: "text", text: "Review disabled agent path" }] as never })
+      await iface.event({ event: { type: "message.part.updated", properties: { part: { type: "text", sessionID: "s1", text: "Primary disabled" } } } as never })
+      await iface.event({ event: { type: "message.updated", properties: { info: { id: "msg-disabled", role: "assistant", sessionID: "s1", tokens: { input: 1 } } } } as never })
+
+      expect(state.createCalls.length).toBe(0)
+      expect(state.promptCalls.length).toBe(0)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/src/plugin/plugin-interface.ts
+++ b/src/plugin/plugin-interface.ts
@@ -40,7 +40,7 @@ export function createPluginInterface(args: {
     },
     event: async (input) => adapter.handleEvent({ event: input.event as never }),
     "tool.execute.before": async (input, output) => adapter.handleToolExecuteBefore(input as never, output as never),
-    "tool.execute.after": async (input, _output) => adapter.handleToolExecuteAfter(input as never),
+    "tool.execute.after": async (input, output) => adapter.handleToolExecuteAfter(input as never, output as never),
     "command.execute.before": async (input, output) => adapter.handleCommandExecuteBefore(input as never, output as never),
     "tool.definition": async (input, output) => adapter.handleToolDefinition(input as never, output as never),
     "experimental.session.compacting": async (input) => adapter.handleSessionCompacting(input as never),

--- a/src/runtime/opencode/apply-effects.test.ts
+++ b/src/runtime/opencode/apply-effects.test.ts
@@ -1,5 +1,62 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, mock } from "bun:test"
+import type { ReviewerPlan } from "../../agents/review-resolver"
 import { applyRuntimeEffects } from "./apply-effects"
+
+function fanOutPlan(scope: "direct" | "post-execution"): ReviewerPlan {
+  return {
+    kind: "fan-out",
+    scope,
+    baseAgent: "weft",
+    primary: { agentName: "weft", label: "Weft", model: "openai/gpt-4o" },
+    variants: [
+      { baseAgent: "weft", key: "weft.reviewer.1", model: "anthropic/claude-sonnet-4", label: "weft @ anthropic/claude-sonnet-4" },
+      { baseAgent: "weft", key: "weft.reviewer.2", model: "google/gemini-2.5-pro", label: "weft @ google/gemini-2.5-pro" },
+    ],
+    batch: { mode: "parallel", size: 3 },
+  }
+}
+
+function primaryOnlyPlan(scope: "direct" | "post-execution"): ReviewerPlan {
+  return {
+    kind: "primary-only",
+    scope,
+    baseAgent: "weft",
+    primary: { agentName: "weft", label: "Weft", model: "openai/gpt-4o" },
+    reason: "no-variants",
+  }
+}
+
+function makeReviewerClient() {
+  let sessionIndex = 0
+  const createCalls: string[] = []
+  const promptAsyncCalls: Array<{ path: { id: string }; body: { parts: Array<{ type: string; text?: string }> } }> = []
+
+  const client = {
+    session: {
+      create: mock(async (input?: { title?: string }) => {
+        sessionIndex += 1
+        createCalls.push(input?.title ?? "")
+        return { data: { id: `review-session-${sessionIndex}` } }
+      }),
+      prompt: mock(async (input: { body?: { model?: { providerID?: string; modelID?: string }; parts?: Array<{ text?: string }> } }) => {
+        const text = input.body?.parts?.[0]?.text ?? ""
+        const provider = input.body?.model?.providerID ?? "unknown"
+        const model = input.body?.model?.modelID ?? "unknown"
+
+        if (text.includes("You are collating multiple AI review outputs into a single consolidated review.")) {
+          return { data: { output: "collated output" } }
+        }
+
+        return { data: { output: `review:${provider}/${model}` } }
+      }),
+      promptAsync: mock(async (input: { path: { id: string }; body: { parts: Array<{ type: string; text?: string }> } }) => {
+        promptAsyncCalls.push(input)
+      }),
+    },
+  }
+
+  return { client, createCalls, promptAsyncCalls }
+}
 
 describe("applyRuntimeEffects", () => {
   it("switches agent and appends prompt text", async () => {
@@ -86,5 +143,151 @@ describe("applyRuntimeEffects", () => {
     })
 
     expect(output.parts).toEqual([{ type: "text", text: "report" }])
+  })
+
+  it("runs reviewer fan-out in direct scope and creates variants + collation sessions", async () => {
+    const { client } = makeReviewerClient()
+
+    await applyRuntimeEffects({
+      effects: [{
+        type: "runReviewerFanOut",
+        sessionId: "origin-session",
+        plan: fanOutPlan("direct"),
+        capturedPrimaryOutput: "primary direct output",
+        promptText: "review this",
+        originalContext: "ctx",
+        idempotencyKey: "k1",
+        delivery: { kind: "injectPromptAsync" },
+      }],
+      client: client as never,
+    })
+
+    expect(client.session.create).toHaveBeenCalledTimes(3)
+  })
+
+  it("runs reviewer fan-out in post-execution scope and creates primary + variants + collation sessions", async () => {
+    const { client } = makeReviewerClient()
+
+    await applyRuntimeEffects({
+      effects: [{
+        type: "runReviewerFanOut",
+        sessionId: "origin-session",
+        plan: fanOutPlan("post-execution"),
+        promptText: "review this",
+        originalContext: "ctx",
+        idempotencyKey: "k2",
+        delivery: { kind: "injectPromptAsync" },
+      }],
+      client: client as never,
+    })
+
+    expect(client.session.create).toHaveBeenCalledTimes(4)
+  })
+
+  it("runs primary-only in post-execution scope with exactly one session.create", async () => {
+    const { client } = makeReviewerClient()
+
+    await applyRuntimeEffects({
+      effects: [{
+        type: "runReviewerFanOut",
+        sessionId: "origin-session",
+        plan: primaryOnlyPlan("post-execution"),
+        promptText: "review this",
+        originalContext: "ctx",
+        idempotencyKey: "k3",
+        delivery: { kind: "injectPromptAsync" },
+      }],
+      client: client as never,
+    })
+
+    expect(client.session.create).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs primary-only in direct scope with zero session.create", async () => {
+    const { client } = makeReviewerClient()
+
+    await applyRuntimeEffects({
+      effects: [{
+        type: "runReviewerFanOut",
+        sessionId: "origin-session",
+        plan: primaryOnlyPlan("direct"),
+        capturedPrimaryOutput: "primary direct output",
+        promptText: "review this",
+        originalContext: "ctx",
+        idempotencyKey: "k4",
+        delivery: { kind: "injectPromptAsync" },
+      }],
+      client: client as never,
+    })
+
+    expect(client.session.create).toHaveBeenCalledTimes(0)
+  })
+
+  it("dedupes second runReviewerFanOut invocation by idempotency key", async () => {
+    const { client } = makeReviewerClient()
+    const effect = {
+      type: "runReviewerFanOut" as const,
+      sessionId: "origin-session",
+      plan: fanOutPlan("post-execution"),
+      promptText: "review this",
+      originalContext: "ctx",
+      idempotencyKey: "shared-key",
+      delivery: { kind: "injectPromptAsync" as const },
+    }
+
+    await applyRuntimeEffects({ effects: [effect], client: client as never })
+    await applyRuntimeEffects({ effects: [effect], client: client as never })
+
+    expect(client.session.create).toHaveBeenCalledTimes(4)
+    expect(client.session.promptAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not suppress fan-out when prompt text contains sentinel", async () => {
+    const { client } = makeReviewerClient()
+
+    await applyRuntimeEffects({
+      effects: [{
+        type: "runReviewerFanOut",
+        sessionId: "origin-session",
+        plan: fanOutPlan("post-execution"),
+        promptText: "review this <!-- weave:reviewer-fanout --> now",
+        originalContext: "ctx",
+        idempotencyKey: "k-sentinel",
+        delivery: { kind: "injectPromptAsync" },
+      }],
+      client: client as never,
+    })
+
+    expect(client.session.create).toHaveBeenCalledTimes(4)
+    expect(client.session.promptAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("delivers final reviewer output via session.promptAsync with sentinel header", async () => {
+    const { client, promptAsyncCalls } = makeReviewerClient()
+    const recorded: Array<{ sessionId: string; text: string; metadata?: { kind: string; nonce?: string } }> = []
+
+    await applyRuntimeEffects({
+      effects: [{
+        type: "runReviewerFanOut",
+        sessionId: "origin-session",
+        plan: fanOutPlan("post-execution"),
+        promptText: "review this",
+        originalContext: "ctx",
+        idempotencyKey: "k5",
+        delivery: { kind: "injectPromptAsync" },
+      }],
+      client: client as never,
+      recordInjectedPrompt: (sessionId, text, metadata) => {
+        recorded.push({ sessionId, text, metadata: metadata as { kind: string; nonce?: string } | undefined })
+      },
+    })
+
+    expect(client.session.promptAsync).toHaveBeenCalledTimes(1)
+    expect(promptAsyncCalls[0]?.path.id).toBe("origin-session")
+    expect(promptAsyncCalls[0]?.body.parts[0]?.text).toContain("<!-- weave:reviewer-fanout -->")
+    expect(promptAsyncCalls[0]?.body.parts[0]?.text).toMatch(/nonce:[0-9a-f-]{36}/i)
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]?.metadata?.kind).toBe("reviewer-fanout")
+    expect(recorded[0]?.metadata?.nonce).toMatch(/^[0-9a-f-]{36}$/i)
   })
 })

--- a/src/runtime/opencode/apply-effects.ts
+++ b/src/runtime/opencode/apply-effects.ts
@@ -1,15 +1,31 @@
 import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { createSessionClient } from "../../infrastructure/opencode/session-client"
+import { runReviewerFanOut } from "../../agents/review-orchestrator"
 import type { PluginContext } from "../../plugin/types"
 import type { SessionTracker } from "../../features/analytics"
 import type { RuntimeEffect } from "./effects"
+import { randomUUID } from "node:crypto"
+import type { TrustedInjectedPromptMetadata } from "./trusted-message-state"
+
+const REVIEWER_FANOUT_SENTINEL = "<!-- weave:reviewer-fanout -->"
+const reviewerFanOutSeenByClient = new WeakMap<object, Set<string>>()
+
+function getReviewerFanOutSeenSet(client: PluginContext["client"]): Set<string> {
+  const key = client as unknown as object
+  let seen = reviewerFanOutSeenByClient.get(key)
+  if (!seen) {
+    seen = new Set<string>()
+    reviewerFanOutSeenByClient.set(key, seen)
+  }
+  return seen
+}
 
 export async function applyRuntimeEffects(args: {
   effects: RuntimeEffect[]
   output?: { message?: Record<string, unknown>; parts?: Array<{ type: string; text?: string }> }
   client?: PluginContext["client"]
   tracker?: SessionTracker
-  recordInjectedPrompt?: (sessionId: string, text: string) => void
+  recordInjectedPrompt?: (sessionId: string, text: string, metadata?: TrustedInjectedPromptMetadata) => void
   pausePlan?: () => void
   pauseWorkflow?: (reason: string) => void
 }): Promise<void> {
@@ -93,6 +109,51 @@ export async function applyRuntimeEffects(args: {
             tracker.trackToolEnd(event.sessionId, event.tool, event.callId, event.agent)
             break
         }
+        break
+      }
+      case "runReviewerFanOut": {
+        if (!client) {
+          break
+        }
+
+        const seen = getReviewerFanOutSeenSet(client)
+        if (seen.has(effect.idempotencyKey)) {
+          break
+        }
+
+        // Record idempotency key before execution (including failures) to avoid retry storms.
+        seen.add(effect.idempotencyKey)
+
+        try {
+          const { output: fanOutOutput, failureWarning } = await runReviewerFanOut({
+            plan: effect.plan,
+            capturedPrimaryOutput: effect.capturedPrimaryOutput,
+            promptText: effect.promptText,
+            originalContext: effect.originalContext,
+            client,
+          })
+
+          if (!fanOutOutput) {
+            break
+          }
+
+          const mergedOutput = failureWarning && !fanOutOutput.startsWith(failureWarning)
+            ? `${failureWarning}\n\n${fanOutOutput}`
+            : fanOutOutput
+          const nonce = randomUUID()
+          const taggedOutput = `${REVIEWER_FANOUT_SENTINEL} <!-- weave:reviewer-fanout nonce:${nonce} -->\n${mergedOutput}`
+
+          if (effect.delivery.kind === "injectPromptAsync") {
+            await client.session.promptAsync({
+              path: { id: effect.sessionId },
+              body: { parts: [{ type: "text", text: taggedOutput }] },
+            })
+            recordInjectedPrompt?.(effect.sessionId, taggedOutput, { kind: "reviewer-fanout", nonce })
+          }
+        } catch (error) {
+          console.error("[weave:ERROR] runReviewerFanOut effect failed", error)
+        }
+
         break
       }
     }

--- a/src/runtime/opencode/effects.ts
+++ b/src/runtime/opencode/effects.ts
@@ -1,8 +1,11 @@
+import type { ReviewerPlan } from "../../agents/review-resolver"
+
 export type RuntimeEffect =
   | SwitchAgentEffect
   | RestoreAgentEffect
   | AppendPromptTextEffect
   | InjectPromptAsyncEffect
+  | RunReviewerFanOutEffect
   | PauseExecutionEffect
   | TrackAnalyticsEffect
   | AppendCommandOutputEffect
@@ -29,6 +32,19 @@ export interface InjectPromptAsyncEffect {
   sessionId: string
   text: string
   agent?: string | null
+}
+
+export interface RunReviewerFanOutEffect {
+  type: "runReviewerFanOut"
+  sessionId: string
+  plan: ReviewerPlan
+  capturedPrimaryOutput?: string
+  promptText: string
+  originalContext: string
+  /** Idempotency token. Direct scope: `${sessionId}:${messageId}`. Post-execution: `${sessionId}:${planSha}:${baseAgent}`. */
+  idempotencyKey: string
+  /** Delivery primitive — reuses the existing `injectPromptAsync` runtime effect path in `apply-effects.ts` (posts to the originating session via `client.session.promptAsync`). */
+  delivery: { kind: "injectPromptAsync" }
 }
 
 export interface PauseExecutionEffect {

--- a/src/runtime/opencode/event-router.test.ts
+++ b/src/runtime/opencode/event-router.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test"
+import { routeRuntimeEvent, type EventRouterState } from "./event-router"
+import type { RuntimeLifecyclePolicySurface } from "../../application/orchestration/session-runtime"
+import type { CreatedHooks } from "../../hooks/create-hooks"
+import { DEFAULT_CONTINUATION_CONFIG } from "../../config/continuation"
+
+function makeHooks(overrides?: Partial<CreatedHooks>): CreatedHooks {
+  return {
+    contextWindowThresholds: null,
+    rulesInjectorEnabled: false,
+    writeGuard: null,
+    firstMessageVariant: null,
+    processMessageForKeywords: null,
+    patternMdOnlyEnabled: false,
+    startWork: null,
+    workContinuation: null,
+    workflowStart: null,
+    workflowContinuation: null,
+    workflowCommand: null,
+    verificationReminderEnabled: false,
+    analyticsEnabled: false,
+    todoDescriptionOverrideEnabled: false,
+    compactionTodoPreserverEnabled: false,
+    todoContinuationEnforcerEnabled: false,
+    compactionRecovery: null,
+    continuation: DEFAULT_CONTINUATION_CONFIG,
+    ...overrides,
+  }
+}
+
+function makeLifecyclePolicy(
+  overrides?: Partial<RuntimeLifecyclePolicySurface>,
+): RuntimeLifecyclePolicySurface {
+  return {
+    onChatMessage: async () => [],
+    beforeTool: async () => [],
+    afterTool: async () => [],
+    onToolDefinition: async () => undefined,
+    onAssistantMessage: async () => [],
+    onSessionIdle: async () => [],
+    onSessionDeleted: async () => [],
+    beforeCompaction: async () => undefined,
+    onCompaction: async () => [],
+    ...overrides,
+  }
+}
+
+describe("routeRuntimeEvent", () => {
+  it("passes assistantText and originalPromptText to onAssistantMessage", async () => {
+    const state: EventRouterState = {
+      lastAssistantMessageText: new Map([["sess-1", "latest assistant text"]]),
+      lastUserMessageText: new Map([["sess-1", "latest user prompt"]]),
+      lastUserMessageTrustedInjectedKind: new Map([["sess-1", "reviewer-fanout"]]),
+    }
+    const onAssistantMessageCalls: Array<Parameters<RuntimeLifecyclePolicySurface["onAssistantMessage"]>[0]> = []
+    const lifecyclePolicy = makeLifecyclePolicy({
+      onAssistantMessage: async (input) => {
+        onAssistantMessageCalls.push(input)
+        return []
+      },
+    })
+
+    await routeRuntimeEvent({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg-1",
+            role: "assistant",
+            sessionID: "sess-1",
+            tokens: { input: 123 },
+          },
+        },
+      },
+      directory: "C:/workspace",
+      hooks: makeHooks(),
+      state,
+      lifecyclePolicy,
+    })
+
+    expect(onAssistantMessageCalls).toHaveLength(1)
+    expect(onAssistantMessageCalls[0]).toEqual(
+      expect.objectContaining({
+        directory: "C:/workspace",
+        sessionId: "sess-1",
+        inputTokens: 123,
+        assistantText: "latest assistant text",
+        originalPromptText: "latest user prompt",
+        respondingToTrustedInjectedPromptKind: "reviewer-fanout",
+        messageId: "msg-1",
+      }),
+    )
+  })
+})

--- a/src/runtime/opencode/event-router.ts
+++ b/src/runtime/opencode/event-router.ts
@@ -12,10 +12,12 @@ import type { RuntimeLifecyclePolicySurface } from "../../application/orchestrat
 import type { RuntimePolicyFlags } from "../../application/orchestration/session-runtime"
 import { doesSessionOwnExecution } from "../../application/orchestration/execution-coordinator"
 import { createExecutionLeaseFsStore } from "../../infrastructure/fs/execution-lease-fs-store"
+import type { TrustedInjectedPromptKind } from "./trusted-message-state"
 
 export interface EventRouterState {
   lastAssistantMessageText: Map<string, string>
   lastUserMessageText: Map<string, string>
+  lastUserMessageTrustedInjectedKind: Map<string, TrustedInjectedPromptKind | null>
 }
 
 const ExecutionLeaseRepository = createExecutionLeaseFsStore()
@@ -104,14 +106,21 @@ export async function routeRuntimeEvent(input: {
   if (event.type === "message.updated") {
     const evt = event as {
       type: string
-      properties: { info: { role?: string; sessionID?: string; cost?: number; tokens?: { input?: number; output?: number; reasoning?: number; cache?: { read?: number; write?: number } } } }
+      properties: { info: { id?: string; role?: string; sessionID?: string; cost?: number; tokens?: { input?: number; output?: number; reasoning?: number; cache?: { read?: number; write?: number } } } }
     }
     const info = evt.properties?.info
     if (info?.role === "assistant" && info.sessionID) {
+      const sessionRuntime = ExecutionLeaseRepository.readSessionRuntime(directory, info.sessionID)
       effects.push(...(await lifecyclePolicy.onAssistantMessage({
+        directory,
         sessionId: info.sessionID,
         hooks: policyFlags,
         inputTokens: info.tokens?.input ?? 0,
+        foregroundAgent: sessionRuntime?.foreground_agent,
+        assistantText: state.lastAssistantMessageText.get(info.sessionID),
+        originalPromptText: state.lastUserMessageText.get(info.sessionID),
+        respondingToTrustedInjectedPromptKind: state.lastUserMessageTrustedInjectedKind.get(info.sessionID) ?? null,
+        messageId: info.id,
       })))
 
       if (tracker && hooks.analyticsEnabled) {

--- a/src/runtime/opencode/plugin-adapter.ts
+++ b/src/runtime/opencode/plugin-adapter.ts
@@ -13,12 +13,16 @@ import { setContextLimit } from "../../hooks"
 import type { RuntimeEffect } from "./effects"
 import { createRuntimeLifecyclePolicySurface } from "../../application/orchestration/session-runtime"
 import type { RuntimePolicyFlags } from "../../application/orchestration/session-runtime"
+import { buildFailureWarning, collateReviews, runAdditionalReviewers } from "../../agents/review-orchestrator"
+import { AGENT_MODEL_REQUIREMENTS } from "../../agents/model-resolution"
 import { createExecutionLeaseFsStore } from "../../infrastructure/fs/execution-lease-fs-store"
-import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { getAgentConfigKey, getAgentDisplayName } from "../../shared/agent-display-names"
 import { projectExecutionTransition } from "../../domain/session/execution-lease"
 import { createTrustedMessageState } from "./trusted-message-state"
 import type { BuiltinCommandEnvelopeName } from "./protocol"
 import { buildEnabledAgentKeys } from "./enabled-agent-keys"
+
+const ReviewCollationFailureWarning = "⚠️ Review collation failed. Showing primary model review only."
 
 export function createPluginAdapter(args: {
   pluginConfig: WeaveConfig
@@ -36,6 +40,12 @@ export function createPluginAdapter(args: {
   const lifecyclePolicy = createRuntimeLifecyclePolicySurface({ hooks, client: trackedClient })
   const executionLeaseRepository = createExecutionLeaseFsStore()
   const enabledAgents = buildEnabledAgentKeys(pluginConfig)
+  const reviewModelsMap: Record<string, string[]> = {}
+  for (const [agentName, override] of Object.entries(pluginConfig.agents ?? {})) {
+    if (override.review_models && override.review_models.length > 0) {
+      reviewModelsMap[agentName] = override.review_models
+    }
+  }
 
   const lastAssistantMessageText = new Map<string, string>()
   const lastUserMessageText = new Map<string, string>()
@@ -247,11 +257,73 @@ export function createPluginAdapter(args: {
       await applyRuntimeEffects({ effects, tracker })
     },
 
-    handleToolExecuteAfter: async (input: { sessionID: string; tool: string; callID: string; args?: Record<string, unknown> }) => {
+    handleToolExecuteAfter: async (
+      input: { sessionID: string; tool: string; callID: string; args?: Record<string, unknown> },
+      output: { title?: string; output?: string; metadata?: unknown },
+    ) => {
       if (input.tool === "task") {
         const inputArgs = input.args
         const agentArg = (inputArgs?.subagent_type as string | undefined) ?? (inputArgs?.description as string | undefined) ?? "unknown"
         logDelegation({ phase: "complete", agent: agentArg, sessionId: input.sessionID, toolCallId: input.callID })
+      }
+
+      if (input.tool === "call_weave_agent" && trackedClient) {
+        const targetAgent = (input.args?.agent as string | undefined) ?? ""
+        const reviewModels = reviewModelsMap[targetAgent] ?? []
+        if (reviewModels.length > 0 && output.output) {
+          const primaryOutput = output.output
+          const originalContext = (input.args?.prompt as string | undefined) ?? ""
+          const configModel = pluginConfig.agents?.[targetAgent]?.model
+          let primaryModel = configModel ?? ""
+          if (!primaryModel) {
+            const requirement = AGENT_MODEL_REQUIREMENTS[targetAgent as keyof typeof AGENT_MODEL_REQUIREMENTS]
+            if (requirement?.fallbackChain[0]) {
+              const entry = requirement.fallbackChain[0]
+              primaryModel = `${entry.providers[0]}/${entry.model}`
+              debug("[review-orchestration] No explicit model override — using default for collation", { agent: targetAgent, model: primaryModel })
+            }
+          }
+
+          try {
+            const additionalResults = await runAdditionalReviewers({
+              agentName: targetAgent,
+              reviewModels,
+              prompt: originalContext,
+              client: trackedClient,
+            })
+
+            const failedCount = additionalResults.filter((result) => !result.success).length
+            const allFailed = failedCount >= additionalResults.length
+
+            if (allFailed) {
+              output.output = buildFailureWarning({ totalAdditional: reviewModels.length, failedCount }) + "\n\n" + primaryOutput
+            } else {
+              const collated = await collateReviews({
+                agentName: targetAgent,
+                primaryModel,
+                primaryOutput,
+                additionalResults,
+                originalContext,
+                client: trackedClient,
+              })
+              const warning = failedCount > 0
+                ? buildFailureWarning({ totalAdditional: reviewModels.length, failedCount }) + "\n\n"
+                : ""
+              output.output = warning + collated
+            }
+
+            const modelCount = reviewModels.length - failedCount + 1
+            output.title = `${getAgentDisplayName(targetAgent)} Review (${modelCount} model${modelCount !== 1 ? "s" : ""})`
+          } catch (error) {
+            debug("[review-orchestration] Collation failed; preserving primary output", {
+              agent: targetAgent,
+              primaryModel,
+              error: error instanceof Error ? error.message : String(error),
+            })
+            output.output = `${ReviewCollationFailureWarning}\n\n${primaryOutput}`
+            output.title = `${getAgentDisplayName(targetAgent)} Review (1 model)`
+          }
+        }
       }
 
       const effects: RuntimeEffect[] = []
@@ -329,6 +401,16 @@ function wrapClientWithTrustedPromptTracking(
     session: Object.assign({}, client.session, {
       promptAsync: (input: Parameters<typeof client.session.promptAsync>[0]) => {
         const result = client.session.promptAsync(input)
+        const text = extractPromptText(input.body)
+        return result.then((value) => {
+          if (text) {
+            trustedMessageState.registerInjectedPrompt(input.path.id, text)
+          }
+          return value
+        }) as typeof result
+      },
+      prompt: (input: Parameters<typeof client.session.prompt>[0]) => {
+        const result = client.session.prompt(input)
         const text = extractPromptText(input.body)
         return result.then((value) => {
           if (text) {

--- a/src/runtime/opencode/plugin-adapter.ts
+++ b/src/runtime/opencode/plugin-adapter.ts
@@ -13,16 +13,12 @@ import { setContextLimit } from "../../hooks"
 import type { RuntimeEffect } from "./effects"
 import { createRuntimeLifecyclePolicySurface } from "../../application/orchestration/session-runtime"
 import type { RuntimePolicyFlags } from "../../application/orchestration/session-runtime"
-import { buildFailureWarning, collateReviews, runAdditionalReviewers } from "../../agents/review-orchestrator"
-import { AGENT_MODEL_REQUIREMENTS } from "../../agents/model-resolution"
 import { createExecutionLeaseFsStore } from "../../infrastructure/fs/execution-lease-fs-store"
-import { getAgentConfigKey, getAgentDisplayName } from "../../shared/agent-display-names"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { projectExecutionTransition } from "../../domain/session/execution-lease"
 import { createTrustedMessageState } from "./trusted-message-state"
 import type { BuiltinCommandEnvelopeName } from "./protocol"
 import { buildEnabledAgentKeys } from "./enabled-agent-keys"
-
-const ReviewCollationFailureWarning = "⚠️ Review collation failed. Showing primary model review only."
 
 export function createPluginAdapter(args: {
   pluginConfig: WeaveConfig
@@ -40,13 +36,8 @@ export function createPluginAdapter(args: {
   const lifecyclePolicy = createRuntimeLifecyclePolicySurface({ hooks, client: trackedClient })
   const executionLeaseRepository = createExecutionLeaseFsStore()
   const enabledAgents = buildEnabledAgentKeys(pluginConfig)
-  const reviewModelsMap: Record<string, string[]> = {}
-  for (const [agentName, override] of Object.entries(pluginConfig.agents ?? {})) {
-    if (override.review_models && override.review_models.length > 0) {
-      reviewModelsMap[agentName] = override.review_models
-    }
-  }
 
+  const pendingToolArgs = new Map<string, Record<string, unknown>>()
   const lastAssistantMessageText = new Map<string, string>()
   const lastUserMessageText = new Map<string, string>()
 
@@ -229,6 +220,9 @@ export function createPluginAdapter(args: {
 
     handleToolExecuteBefore: async (input: { sessionID: string; tool: string; callID: string; agent?: string }, output: { args?: Record<string, unknown> | null }) => {
       const toolArgs = output.args as Record<string, unknown> | null | undefined
+      if (toolArgs) {
+        pendingToolArgs.set(toolArgsKey(input.sessionID, input.callID), toolArgs)
+      }
 
       if (input.tool === "task" && toolArgs) {
         const agentArg = (toolArgs.subagent_type as string | undefined) ?? (toolArgs.description as string | undefined) ?? "unknown"
@@ -261,69 +255,14 @@ export function createPluginAdapter(args: {
       input: { sessionID: string; tool: string; callID: string; args?: Record<string, unknown> },
       output: { title?: string; output?: string; metadata?: unknown },
     ) => {
+      const pendingArgsKey = toolArgsKey(input.sessionID, input.callID)
+      const effectiveArgs = input.args ?? pendingToolArgs.get(pendingArgsKey)
+      pendingToolArgs.delete(pendingArgsKey)
+
       if (input.tool === "task") {
-        const inputArgs = input.args
+        const inputArgs = effectiveArgs
         const agentArg = (inputArgs?.subagent_type as string | undefined) ?? (inputArgs?.description as string | undefined) ?? "unknown"
         logDelegation({ phase: "complete", agent: agentArg, sessionId: input.sessionID, toolCallId: input.callID })
-      }
-
-      if (input.tool === "call_weave_agent" && trackedClient) {
-        const targetAgent = (input.args?.agent as string | undefined) ?? ""
-        const reviewModels = reviewModelsMap[targetAgent] ?? []
-        if (reviewModels.length > 0 && output.output) {
-          const primaryOutput = output.output
-          const originalContext = (input.args?.prompt as string | undefined) ?? ""
-          const configModel = pluginConfig.agents?.[targetAgent]?.model
-          let primaryModel = configModel ?? ""
-          if (!primaryModel) {
-            const requirement = AGENT_MODEL_REQUIREMENTS[targetAgent as keyof typeof AGENT_MODEL_REQUIREMENTS]
-            if (requirement?.fallbackChain[0]) {
-              const entry = requirement.fallbackChain[0]
-              primaryModel = `${entry.providers[0]}/${entry.model}`
-              debug("[review-orchestration] No explicit model override — using default for collation", { agent: targetAgent, model: primaryModel })
-            }
-          }
-
-          try {
-            const additionalResults = await runAdditionalReviewers({
-              agentName: targetAgent,
-              reviewModels,
-              prompt: originalContext,
-              client: trackedClient,
-            })
-
-            const failedCount = additionalResults.filter((result) => !result.success).length
-            const allFailed = failedCount >= additionalResults.length
-
-            if (allFailed) {
-              output.output = buildFailureWarning({ totalAdditional: reviewModels.length, failedCount }) + "\n\n" + primaryOutput
-            } else {
-              const collated = await collateReviews({
-                agentName: targetAgent,
-                primaryModel,
-                primaryOutput,
-                additionalResults,
-                originalContext,
-                client: trackedClient,
-              })
-              const warning = failedCount > 0
-                ? buildFailureWarning({ totalAdditional: reviewModels.length, failedCount }) + "\n\n"
-                : ""
-              output.output = warning + collated
-            }
-
-            const modelCount = reviewModels.length - failedCount + 1
-            output.title = `${getAgentDisplayName(targetAgent)} Review (${modelCount} model${modelCount !== 1 ? "s" : ""})`
-          } catch (error) {
-            debug("[review-orchestration] Collation failed; preserving primary output", {
-              agent: targetAgent,
-              primaryModel,
-              error: error instanceof Error ? error.message : String(error),
-            })
-            output.output = `${ReviewCollationFailureWarning}\n\n${primaryOutput}`
-            output.title = `${getAgentDisplayName(targetAgent)} Review (1 model)`
-          }
-        }
       }
 
       const effects: RuntimeEffect[] = []
@@ -333,10 +272,10 @@ export function createPluginAdapter(args: {
         tool: input.tool,
         callId: input.callID,
         hooks: policyFlags,
-        toolArgs: input.args,
+        toolArgs: effectiveArgs,
       })))
       if (tracker && hooks.analyticsEnabled) {
-        const inputArgs = input.args
+        const inputArgs = effectiveArgs
         const agentArg = input.tool === "task"
           ? ((inputArgs?.subagent_type as string | undefined) ?? (inputArgs?.description as string | undefined) ?? "unknown")
           : undefined
@@ -390,6 +329,10 @@ function isBuiltinChatCommand(command: string): command is BuiltinCommandEnvelop
     || command === "metrics"
     || command === "token-report"
     || command === "weave-health"
+}
+
+function toolArgsKey(sessionId: string, callId: string): string {
+  return `${sessionId}:${callId}`
 }
 
 function wrapClientWithTrustedPromptTracking(

--- a/src/runtime/opencode/plugin-adapter.ts
+++ b/src/runtime/opencode/plugin-adapter.ts
@@ -13,12 +13,14 @@ import { setContextLimit } from "../../hooks"
 import type { RuntimeEffect } from "./effects"
 import { createRuntimeLifecyclePolicySurface } from "../../application/orchestration/session-runtime"
 import type { RuntimePolicyFlags } from "../../application/orchestration/session-runtime"
+import { resolveReviewers } from "../../agents/review-resolver"
 import { createExecutionLeaseFsStore } from "../../infrastructure/fs/execution-lease-fs-store"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { projectExecutionTransition } from "../../domain/session/execution-lease"
 import { createTrustedMessageState } from "./trusted-message-state"
 import type { BuiltinCommandEnvelopeName } from "./protocol"
 import { buildEnabledAgentKeys } from "./enabled-agent-keys"
+import type { TrustedInjectedPromptKind } from "./trusted-message-state"
 
 export function createPluginAdapter(args: {
   pluginConfig: WeaveConfig
@@ -33,13 +35,29 @@ export function createPluginAdapter(args: {
   const { pluginConfig, hooks, configHandler, agents, client, directory = "", tracker } = args
   const trustedMessageState = createTrustedMessageState()
   const trackedClient = client ? wrapClientWithTrustedPromptTracking(client, trustedMessageState) : undefined
-  const lifecyclePolicy = createRuntimeLifecyclePolicySurface({ hooks, client: trackedClient })
-  const executionLeaseRepository = createExecutionLeaseFsStore()
   const enabledAgents = buildEnabledAgentKeys(pluginConfig)
+  const disabledSet = new Set((pluginConfig.disabled_agents ?? []).filter((agentKey) => !enabledAgents.has(agentKey)))
+  const reviewerResolver = {
+    forBaseAgent(baseAgent: "weft" | "warp", scope: "direct" | "post-execution") {
+      const overrides = pluginConfig.agents
+      const primaryModel = overrides?.[baseAgent]?.model
+        ?? (typeof agents[baseAgent]?.model === "string" ? agents[baseAgent].model : "")
+      return resolveReviewers({
+        scope,
+        baseAgent,
+        agentOverrides: overrides,
+        disabledAgents: disabledSet,
+        primaryModel,
+      })
+    },
+  }
+  const lifecyclePolicy = createRuntimeLifecyclePolicySurface({ hooks, client: trackedClient, reviewerResolver })
+  const executionLeaseRepository = createExecutionLeaseFsStore()
 
   const pendingToolArgs = new Map<string, Record<string, unknown>>()
   const lastAssistantMessageText = new Map<string, string>()
   const lastUserMessageText = new Map<string, string>()
+  const lastUserMessageTrustedInjectedKind = new Map<string, TrustedInjectedPromptKind | null>()
 
   const policyFlags: RuntimePolicyFlags = {
     contextWindowThresholds: hooks.contextWindowThresholds,
@@ -48,6 +66,9 @@ export function createPluginAdapter(args: {
     verificationReminderEnabled: hooks.verificationReminderEnabled,
     todoDescriptionOverrideEnabled: hooks.todoDescriptionOverrideEnabled,
     todoContinuationEnforcerEnabled: hooks.todoContinuationEnforcerEnabled,
+  }
+  const recordInjectedPrompt = (sessionId: string, text: string, metadata?: { kind: TrustedInjectedPromptKind; nonce?: string }) => {
+    trustedMessageState.registerInjectedPrompt(sessionId, text, metadata)
   }
 
   return {
@@ -108,6 +129,9 @@ export function createPluginAdapter(args: {
           .trim() ?? ""
 
       const parsedEnvelope = trustedMessageState.consumeTrustedEnvelope(sessionID, promptText)
+      const trustedInjectedPrompt = parsedEnvelope === null && promptText
+        ? trustedMessageState.consumeInjectedPrompt(sessionID, promptText)
+        : null
       if (parsedEnvelope?.kind !== "builtin-command") {
         trustedMessageState.clearPendingBuiltin(sessionID)
       }
@@ -129,9 +153,12 @@ export function createPluginAdapter(args: {
       ]
 
       if (promptText && sessionID) {
-        const isSystemInjected = parsedEnvelope !== null
+        const isSystemInjected = parsedEnvelope !== null || trustedInjectedPrompt !== null
         if (!isSystemInjected) {
           lastUserMessageText.set(sessionID, promptText)
+          lastUserMessageTrustedInjectedKind.set(sessionID, null)
+        } else if (trustedInjectedPrompt) {
+          lastUserMessageTrustedInjectedKind.set(sessionID, trustedInjectedPrompt.kind)
         }
       }
 
@@ -140,6 +167,7 @@ export function createPluginAdapter(args: {
         output,
         client: trackedClient,
         tracker,
+        recordInjectedPrompt,
         pausePlan: directory ? () => {
           pauseWork(directory)
           info("[work-continuation] Auto-paused: user message received during active plan", { sessionId: sessionID })
@@ -186,6 +214,7 @@ export function createPluginAdapter(args: {
         trustedMessageState.clearSession(deletedSessionId)
         lastUserMessageText.delete(deletedSessionId)
         lastAssistantMessageText.delete(deletedSessionId)
+        lastUserMessageTrustedInjectedKind.delete(deletedSessionId)
       }
 
       const effects = await routeRuntimeEvent({
@@ -194,7 +223,7 @@ export function createPluginAdapter(args: {
         hooks,
         client: trackedClient,
         tracker,
-        state: { lastAssistantMessageText, lastUserMessageText },
+        state: { lastAssistantMessageText, lastUserMessageText, lastUserMessageTrustedInjectedKind },
         lifecyclePolicy,
         enabledAgents,
       })
@@ -203,6 +232,7 @@ export function createPluginAdapter(args: {
         effects,
         client: trackedClient,
         tracker,
+        recordInjectedPrompt,
         pauseWorkflow: directory ? () => handlePauseExecutionEffect({
           effectReason: "User interrupt",
           directory,

--- a/src/runtime/opencode/trusted-message-state.test.ts
+++ b/src/runtime/opencode/trusted-message-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test"
+import { createTrustedMessageState } from "./trusted-message-state"
+
+describe("trusted-message-state", () => {
+  it("consumes reviewer-fanout injected prompt with kind and nonce", () => {
+    const state = createTrustedMessageState()
+    state.registerInjectedPrompt("sess-1", "Injected reviewer fan-out payload", { kind: "reviewer-fanout", nonce: "abc-123" })
+
+    expect(state.consumeInjectedPrompt("sess-1", "Injected reviewer fan-out payload")).toEqual({ kind: "reviewer-fanout", nonce: "abc-123" })
+  })
+
+  it("consumes generic injected prompt metadata", () => {
+    const state = createTrustedMessageState()
+    state.registerInjectedPrompt("sess-1", "Injected generic payload")
+
+    expect(state.consumeInjectedPrompt("sess-1", "Injected generic payload")).toEqual({ kind: "generic" })
+  })
+
+  it("upgrades generic registration to reviewer-fanout for same text", () => {
+    const state = createTrustedMessageState()
+    state.registerInjectedPrompt("sess-1", "same payload")
+    state.registerInjectedPrompt("sess-1", "same payload", { kind: "reviewer-fanout", nonce: "nonce-1" })
+
+    expect(state.consumeInjectedPrompt("sess-1", "same payload")).toEqual({ kind: "reviewer-fanout", nonce: "nonce-1" })
+  })
+
+  it("consumption is single-use", () => {
+    const state = createTrustedMessageState()
+    state.registerInjectedPrompt("sess-1", "Injected reviewer fan-out payload", { kind: "reviewer-fanout", nonce: "abc-123" })
+
+    expect(state.consumeInjectedPrompt("sess-1", "Injected reviewer fan-out payload")).toEqual({ kind: "reviewer-fanout", nonce: "abc-123" })
+    expect(state.consumeInjectedPrompt("sess-1", "Injected reviewer fan-out payload")).toBeNull()
+    expect(state.consumeTrustedEnvelope("sess-1", "Injected reviewer fan-out payload")).toBeNull()
+  })
+})

--- a/src/runtime/opencode/trusted-message-state.test.ts
+++ b/src/runtime/opencode/trusted-message-state.test.ts
@@ -24,6 +24,25 @@ describe("trusted-message-state", () => {
     expect(state.consumeInjectedPrompt("sess-1", "same payload")).toEqual({ kind: "reviewer-fanout", nonce: "nonce-1" })
   })
 
+  it("preserves distinct reviewer-fanout registrations with same text", () => {
+    const state = createTrustedMessageState()
+    state.registerInjectedPrompt("sess-1", "same payload", { kind: "reviewer-fanout", nonce: "nonce-1" })
+    state.registerInjectedPrompt("sess-1", "same payload", { kind: "reviewer-fanout", nonce: "nonce-2" })
+
+    expect(state.consumeInjectedPrompt("sess-1", "same payload")).toEqual({ kind: "reviewer-fanout", nonce: "nonce-1" })
+    expect(state.consumeInjectedPrompt("sess-1", "same payload")).toEqual({ kind: "reviewer-fanout", nonce: "nonce-2" })
+    expect(state.consumeInjectedPrompt("sess-1", "same payload")).toBeNull()
+  })
+
+  it("deduplicates identical reviewer-fanout registrations", () => {
+    const state = createTrustedMessageState()
+    state.registerInjectedPrompt("sess-1", "same payload", { kind: "reviewer-fanout", nonce: "nonce-1" })
+    state.registerInjectedPrompt("sess-1", "same payload", { kind: "reviewer-fanout", nonce: "nonce-1" })
+
+    expect(state.consumeInjectedPrompt("sess-1", "same payload")).toEqual({ kind: "reviewer-fanout", nonce: "nonce-1" })
+    expect(state.consumeInjectedPrompt("sess-1", "same payload")).toBeNull()
+  })
+
   it("consumption is single-use", () => {
     const state = createTrustedMessageState()
     state.registerInjectedPrompt("sess-1", "Injected reviewer fan-out payload", { kind: "reviewer-fanout", nonce: "abc-123" })

--- a/src/runtime/opencode/trusted-message-state.ts
+++ b/src/runtime/opencode/trusted-message-state.ts
@@ -113,16 +113,27 @@ function addTrustedText(
   const normalizedMetadata: TrustedInjectedPromptMetadata = metadata ?? { kind: "generic" }
   const current = store.get(sessionId) ?? []
 
-  const existing = current.find((entry) => entry.text === text)
-  if (existing) {
-    if (existing.metadata.kind === "generic" && normalizedMetadata.kind === "reviewer-fanout") {
-      existing.metadata = normalizedMetadata
-    }
+  if (normalizedMetadata.kind === "generic" && current.some((entry) => entry.text === text)) {
+    return
+  }
+
+  const existingGeneric = current.find((entry) => entry.text === text && entry.metadata.kind === "generic")
+  if (existingGeneric && normalizedMetadata.kind === "reviewer-fanout") {
+    existingGeneric.metadata = normalizedMetadata
+    return
+  }
+
+  const duplicate = current.some((entry) => entry.text === text && isSameTrustedMetadata(entry.metadata, normalizedMetadata))
+  if (duplicate) {
     return
   }
 
   current.push({ text, metadata: normalizedMetadata })
   store.set(sessionId, current)
+}
+
+function isSameTrustedMetadata(left: TrustedInjectedPromptMetadata, right: TrustedInjectedPromptMetadata): boolean {
+  return left.kind === right.kind && left.nonce === right.nonce
 }
 
 function renderExpectedBuiltinPrompt(input: Extract<ParsedCommandEnvelope, { kind: "builtin-command" }>): string {

--- a/src/runtime/opencode/trusted-message-state.ts
+++ b/src/runtime/opencode/trusted-message-state.ts
@@ -8,9 +8,22 @@ interface PendingBuiltinCommand {
   issuedAt: number
 }
 
+export type TrustedInjectedPromptKind = "generic" | "reviewer-fanout"
+
+export interface TrustedInjectedPromptMetadata {
+  kind: TrustedInjectedPromptKind
+  nonce?: string
+}
+
+interface PendingInjectedPrompt {
+  text: string
+  metadata: TrustedInjectedPromptMetadata
+}
+
 export interface TrustedMessageState {
   registerBuiltinCommand(sessionId: string, command: BuiltinCommandEnvelopeName, argumentsText: string): void
-  registerInjectedPrompt(sessionId: string, text: string): void
+  registerInjectedPrompt(sessionId: string, text: string, metadata?: TrustedInjectedPromptMetadata): void
+  consumeInjectedPrompt(sessionId: string, promptText: string): TrustedInjectedPromptMetadata | null
   clearSession(sessionId: string): void
   clearPendingBuiltin(sessionId: string): void
   consumeTrustedEnvelope(sessionId: string, promptText: string): ParsedCommandEnvelope | null
@@ -18,7 +31,7 @@ export interface TrustedMessageState {
 
 export function createTrustedMessageState(): TrustedMessageState {
   const pendingBuiltinCommands = new Map<string, PendingBuiltinCommand[]>()
-  const pendingInjectedPrompts = new Map<string, string[]>()
+  const pendingInjectedPrompts = new Map<string, PendingInjectedPrompt[]>()
 
   return {
     registerBuiltinCommand(sessionId, command, argumentsText) {
@@ -26,8 +39,22 @@ export function createTrustedMessageState(): TrustedMessageState {
       current.push({ command, argumentsText: normalize(argumentsText), issuedAt: Date.now() })
       pendingBuiltinCommands.set(sessionId, current)
     },
-    registerInjectedPrompt(sessionId, text) {
-      addTrustedText(pendingInjectedPrompts, sessionId, text)
+    registerInjectedPrompt(sessionId, text, metadata) {
+      addTrustedText(pendingInjectedPrompts, sessionId, text, metadata)
+    },
+    consumeInjectedPrompt(sessionId, promptText) {
+      const current = pendingInjectedPrompts.get(sessionId) ?? []
+      const matchedIndex = current.findIndex((candidate) => candidate.text === promptText)
+      if (matchedIndex < 0) {
+        return null
+      }
+
+      const [matched] = current.splice(matchedIndex, 1)
+      if (current.length === 0) {
+        pendingInjectedPrompts.delete(sessionId)
+      }
+
+      return matched?.metadata ?? null
     },
     clearSession(sessionId) {
       pendingBuiltinCommands.delete(sessionId)
@@ -63,15 +90,9 @@ export function createTrustedMessageState(): TrustedMessageState {
         return parsedEnvelope
       }
 
-      const current = pendingInjectedPrompts.get(sessionId) ?? []
-      const matchedIndex = current.findIndex((candidate) => candidate === promptText)
-      if (matchedIndex < 0) {
+      const matchedMetadata = this.consumeInjectedPrompt(sessionId, promptText)
+      if (!matchedMetadata) {
         return null
-      }
-
-      current.splice(matchedIndex, 1)
-      if (current.length === 0) {
-        pendingInjectedPrompts.delete(sessionId)
       }
 
       return parsedEnvelope
@@ -83,9 +104,24 @@ function normalize(value: string): string {
   return value.trim()
 }
 
-function addTrustedText(store: Map<string, string[]>, sessionId: string, text: string): void {
+function addTrustedText(
+  store: Map<string, PendingInjectedPrompt[]>,
+  sessionId: string,
+  text: string,
+  metadata?: TrustedInjectedPromptMetadata,
+): void {
+  const normalizedMetadata: TrustedInjectedPromptMetadata = metadata ?? { kind: "generic" }
   const current = store.get(sessionId) ?? []
-  current.push(text)
+
+  const existing = current.find((entry) => entry.text === text)
+  if (existing) {
+    if (existing.metadata.kind === "generic" && normalizedMetadata.kind === "reviewer-fanout") {
+      existing.metadata = normalizedMetadata
+    }
+    return
+  }
+
+  current.push({ text, metadata: normalizedMetadata })
   store.set(sessionId, current)
 }
 

--- a/test/integration/custom-agent-pipeline.integration.test.ts
+++ b/test/integration/custom-agent-pipeline.integration.test.ts
@@ -253,8 +253,9 @@ describe("E2E: Disabled agents", () => {
 
     const tapestryPrompt = managers.agents["tapestry"]?.prompt ?? ""
 
-    // Tapestry prompt should not reference disabled agent
-    expect(tapestryPrompt).not.toContain("Weft")
+    // Tapestry prompt should not delegate to disabled Weft agent
+    // (advisory text mentions "Weft" generically; check delegation line is absent)
+    expect(tapestryPrompt).not.toContain('Delegate to Weft')
 
     // But should still reference warp
     expect(tapestryPrompt).toContain("Warp")


### PR DESCRIPTION
## Summary
- resolve `@weft` / `@warp` reviewer fan-out from config at runtime instead of leaving visible review variants to LLM prompt compliance
- add direct and post-execution fan-out policies that run configured reviewer variants, collate results, and preserve Weft/Warp boundaries and idempotency
- expand config/schema support, prompt advisories, eval contracts, and focused tests for direct, post-execution, disabled, and no-variant review flows

## Reviewer focus
- `src/agents/review-resolver.ts` and `src/agents/review-orchestrator.ts` — reviewer-set resolution, per-agent fan-out, collation, and failure handling
- `src/application/policy/*reviewer-fanout-session-policy.ts` — direct `@weft` / `@warp` and Tapestry post-execution triggers
- `src/runtime/opencode/*` — new runtime effect plumbing, trusted message/idempotency state, and original prompt capture
- `src/agents/loom/*` and `src/agents/tapestry/*` — advisory prompt updates without relying on the model to enumerate variants

## Testing
- `bun test src/agents/review-resolver.test.ts src/agents/review-orchestrator.test.ts src/application/policy/direct-reviewer-fanout-session-policy.test.ts src/application/policy/post-execution-reviewer-fanout-session-policy.test.ts src/runtime/opencode/apply-effects.test.ts src/runtime/opencode/event-router.test.ts src/plugin/plugin-interface.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent review_models config: runtime runs multiple reviewer models in parallel, collates outputs into one consolidated review, and surfaces failure warnings.
* **Documentation**
  * Clarified runtime-owned reviewer fan-out semantics across direct vs post-execution reviews; updated eval guidance and prompt contracts.
* **Tests**
  * Added extensive unit/integration/eval cases validating planner, orchestration, idempotency, failure handling, and prompt-output contracts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgermishuys/opencode-weave/pull/48)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->